### PR TITLE
Add total question timer and study subjects

### DIFF
--- a/backup.js
+++ b/backup.js
@@ -10,7 +10,8 @@
     sessions: "summer-politics-study-sessions-v1",
     activeSession: "summer-politics-active-study-v1",
     clockShowsSeconds: "summer-politics-clock-seconds-v1",
-    questionTimer: "summer-politics-question-timer-v1"
+    questionTimer: "summer-politics-question-timer-v1",
+    studySubject: "summer-politics-last-study-subject-v1"
   };
 
   const dom = {
@@ -63,7 +64,8 @@
       typeof item.id === "string" &&
       validNumber(item.start, 1) &&
       validNumber(item.end, item.start) &&
-      validNumber(item.durationMs)
+      validNumber(item.durationMs) &&
+      (item.subject === undefined || (typeof item.subject === "string" && item.subject.length <= 30))
     );
     if (!valid) throw new Error("学习计时记录格式不正确");
   }
@@ -76,7 +78,8 @@
       validNumber(value.startedAt, 1) &&
       validNumber(value.accumulatedMs) &&
       ["running", "paused"].includes(value.status) &&
-      (value.status === "paused" || validNumber(value.resumedAt, 1));
+      (value.status === "paused" || validNumber(value.resumedAt, 1)) &&
+      (value.subject === undefined || (typeof value.subject === "string" && value.subject.length <= 30));
     if (!valid) throw new Error("进行中的计时数据格式不正确");
   }
 
@@ -90,14 +93,26 @@
     if (raw === null) return;
     const value = parseStoredJSON(raw, null);
     const statuses = ["idle", "running", "paused", "completed"];
-    const valid = isPlainObject(value) &&
+    const validTotal = isPlainObject(value) && value.mode === "total" &&
+      Number.isInteger(value.totalQuestions) && value.totalQuestions >= 1 && value.totalQuestions <= 200 &&
+      Number.isInteger(value.secondsPerQuestion) && value.secondsPerQuestion >= 30 && value.secondsPerQuestion <= 3600 &&
+      validNumber(value.totalDurationMs, 30000) && statuses.includes(value.status) &&
+      validNumber(value.remainingMs) &&
+      (value.status !== "running" || validNumber(value.endsAt, 1)) &&
+      (value.alertEndsAt === null || value.alertEndsAt === undefined || validNumber(value.alertEndsAt, 1));
+    const validLegacy = isPlainObject(value) &&
       Number.isInteger(value.totalQuestions) && value.totalQuestions >= 1 && value.totalQuestions <= 200 &&
       Number.isInteger(value.secondsPerQuestion) && value.secondsPerQuestion >= 30 && value.secondsPerQuestion <= 3600 &&
       Number.isInteger(value.currentQuestion) && value.currentQuestion >= 1 && value.currentQuestion <= value.totalQuestions &&
-      statuses.includes(value.status) && ["question", "ring"].includes(value.phase) &&
-      validNumber(value.remainingMs) &&
+      statuses.includes(value.status) && ["question", "ring"].includes(value.phase) && validNumber(value.remainingMs) &&
       (value.status !== "running" || validNumber(value.phaseEndsAt, 1));
-    if (!valid) throw new Error("做题计时数据格式不正确");
+    if (!validTotal && !validLegacy) throw new Error("做题计时数据格式不正确");
+  }
+
+  function validateStudySubject(raw) {
+    if (raw !== null && (typeof raw !== "string" || raw.length > 30)) {
+      throw new Error("学习科目设置格式不正确");
+    }
   }
 
   function snapshot() {
@@ -129,12 +144,14 @@
       }
     }
     if (!("questionTimer" in data)) data.questionTimer = null;
+    if (!("studySubject" in data)) data.studySubject = null;
     if (data.questionTimer !== null && typeof data.questionTimer !== "string") throw new Error("做题计时数据格式不正确");
     validateProgress(data.progress);
     validateSessions(data.sessions);
     validateActiveSession(data.activeSession);
     validateClockFormat(data.clockShowsSeconds);
     validateQuestionTimer(data.questionTimer);
+    validateStudySubject(data.studySubject);
     return data;
   }
 

--- a/clock.css
+++ b/clock.css
@@ -205,9 +205,6 @@
   transition: stroke-dashoffset 220ms linear, stroke 180ms ease;
 }
 
-.question-progress-wrap.ringing .question-progress-value,
-.fullscreen-question-progress.ringing .question-progress-value { stroke: #b06b16; }
-
 .question-progress-wrap.completed .question-progress-value,
 .fullscreen-question-progress.completed .question-progress-value { opacity: 0; }
 
@@ -223,7 +220,7 @@
 .question-progress-copy strong {
   margin-top: 5px;
   font-family: "SF Mono", "Roboto Mono", "Courier New", monospace;
-  font-size: 34px;
+  font-size: 31px;
   font-weight: 400;
   font-variant-numeric: tabular-nums;
   line-height: 1;
@@ -501,6 +498,35 @@ body.clock-fullscreen-active { overflow: hidden; background: #000; }
 
 .clock-format-hint { margin-top: 8px; color: var(--muted); font-size: 13px; }
 
+.study-subject-picker {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  max-width: 360px;
+  margin: 22px auto 0;
+  color: var(--muted);
+  font-size: 15px;
+  text-align: left;
+}
+
+.study-subject-picker input {
+  width: 100%;
+  min-height: 46px;
+  padding: 9px 12px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: inherit;
+  font-size: 16px;
+}
+
+.study-subject-picker input:disabled {
+  background: var(--surface-strong);
+  color: var(--muted);
+}
+
 .active-elapsed {
   width: fit-content;
   margin: 16px auto 0;
@@ -613,6 +639,18 @@ body.clock-fullscreen-active { overflow: hidden; background: #000; }
   font-family: "Songti SC", "STSong", "SimSun", Georgia, serif;
   font-size: 24px;
   font-weight: 400;
+  line-height: 1.35;
+}
+
+.record-subject {
+  width: fit-content;
+  margin-bottom: 6px;
+  padding: 3px 7px;
+  border: 1px solid #bfd9d1;
+  border-radius: 3px;
+  background: var(--green-soft);
+  color: var(--green);
+  font-size: 13px;
   line-height: 1.35;
 }
 
@@ -784,6 +822,10 @@ body.clock-fullscreen-active { overflow: hidden; background: #000; }
   background: var(--bg);
   color: var(--ink);
   font-size: 16px;
+}
+
+@media (max-width: 360px) {
+  .study-subject-picker { grid-template-columns: 1fr; gap: 7px; }
 }
 
 .form-error { min-height: 20px; color: var(--red); font-size: 13px; }

--- a/clock.js
+++ b/clock.js
@@ -5,6 +5,7 @@
   const ACTIVE_KEY = "summer-politics-active-study-v1";
   const CLOCK_FORMAT_KEY = "summer-politics-clock-seconds-v1";
   const QUESTION_TIMER_KEY = "summer-politics-question-timer-v1";
+  const LAST_SUBJECT_KEY = "summer-politics-last-study-subject-v1";
   const QUESTION_RING_MS = 7000;
   const DAY_MS = 86400000;
 
@@ -56,10 +57,12 @@
     modal: document.getElementById("timer-edit-modal"),
     editForm: document.getElementById("timer-edit-form"),
     editId: document.getElementById("edit-record-id"),
+    editSubject: document.getElementById("edit-record-subject"),
     editStart: document.getElementById("edit-record-start"),
     editEnd: document.getElementById("edit-record-end"),
     editMinutes: document.getElementById("edit-record-minutes"),
     formError: document.getElementById("timer-form-error"),
+    studySubject: document.getElementById("study-subject"),
     questionCount: document.getElementById("question-count"),
     questionMinutes: document.getElementById("question-minutes"),
     questionProgressWrap: document.getElementById("question-progress-wrap"),
@@ -97,20 +100,24 @@
     const source = value && typeof value === "object" && !Array.isArray(value) ? value : {};
     const totalQuestions = clamp(Math.round(Number(source.totalQuestions) || 40), 1, 200);
     const secondsPerQuestion = clamp(Math.round(Number(source.secondsPerQuestion) || 180), 30, 3600);
-    const currentQuestion = clamp(Math.round(Number(source.currentQuestion) || 1), 1, totalQuestions);
-    const phase = source.phase === "ring" ? "ring" : "question";
+    const totalDurationMs = totalQuestions * secondsPerQuestion * 1000;
     const allowedStatuses = ["idle", "running", "paused", "completed"];
-    let status = allowedStatuses.includes(source.status) ? source.status : "idle";
-    let phaseEndsAt = Number.isFinite(source.phaseEndsAt) ? source.phaseEndsAt : null;
-    const phaseDuration = phase === "ring" ? QUESTION_RING_MS : secondsPerQuestion * 1000;
-    let remainingMs = Number.isFinite(source.remainingMs) ? clamp(source.remainingMs, 0, phaseDuration) : phaseDuration;
+    let status = source.mode === "total" && allowedStatuses.includes(source.status) ? source.status : "idle";
+    let endsAt = Number.isFinite(source.endsAt) ? source.endsAt : null;
+    let alertEndsAt = Number.isFinite(source.alertEndsAt) ? source.alertEndsAt : null;
+    let remainingMs = Number.isFinite(source.remainingMs) ? clamp(source.remainingMs, 0, totalDurationMs) : totalDurationMs;
 
-    if (status === "running" && !phaseEndsAt) status = "paused";
-    if (status !== "running") phaseEndsAt = null;
-    if (status === "idle") remainingMs = secondsPerQuestion * 1000;
+    if (status === "running" && !endsAt) status = "paused";
+    if (status !== "running") endsAt = null;
+    if (status === "idle") remainingMs = totalDurationMs;
     if (status === "completed") remainingMs = 0;
+    if (status !== "completed") alertEndsAt = null;
 
-    return { totalQuestions, secondsPerQuestion, currentQuestion, status, phase, remainingMs, phaseEndsAt };
+    return { mode: "total", totalQuestions, secondsPerQuestion, totalDurationMs, status, remainingMs, endsAt, alertEndsAt };
+  }
+
+  function normalizeSubject(value) {
+    return String(value ?? "").trim().replace(/\s+/g, " ").slice(0, 30);
   }
 
   function saveSessions() {
@@ -193,13 +200,14 @@
 
   function questionCountdown(milliseconds) {
     const totalSeconds = Math.max(0, Math.ceil(milliseconds / 1000));
-    const minutes = Math.floor(totalSeconds / 60);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor(totalSeconds % 3600 / 60);
     const seconds = totalSeconds % 60;
-    return `${pad(minutes)}:${pad(seconds)}`;
+    return hours ? `${pad(hours)}:${pad(minutes)}:${pad(seconds)}` : `${pad(minutes)}:${pad(seconds)}`;
   }
 
   function questionRemaining(now = Date.now()) {
-    if (questionTimer.status === "running") return Math.max(0, questionTimer.phaseEndsAt - now);
+    if (questionTimer.status === "running") return Math.max(0, questionTimer.endsAt - now);
     return Math.max(0, questionTimer.remainingMs);
   }
 
@@ -226,7 +234,7 @@
     bellPhaseEndAt = targetEndAt;
     try {
       const context = await primeQuestionAudio();
-      if (!context || bellPhaseEndAt !== targetEndAt || questionTimer.status !== "running" || questionTimer.phase !== "ring") return;
+      if (!context || bellPhaseEndAt !== targetEndAt || questionTimer.status !== "completed" || questionTimer.alertEndsAt !== targetEndAt) return;
       const startAt = context.currentTime + 0.02;
       const seconds = Math.max(0.1, durationMs / 1000);
       for (let offset = 0; offset < seconds; offset += 0.82) {
@@ -255,48 +263,39 @@
   }
 
   function questionTimerIdle(totalQuestions = questionTimer.totalQuestions, secondsPerQuestion = questionTimer.secondsPerQuestion) {
+    const totalDurationMs = totalQuestions * secondsPerQuestion * 1000;
     return {
+      mode: "total",
       totalQuestions,
       secondsPerQuestion,
-      currentQuestion: 1,
+      totalDurationMs,
       status: "idle",
-      phase: "question",
-      remainingMs: secondsPerQuestion * 1000,
-      phaseEndsAt: null
+      remainingMs: totalDurationMs,
+      endsAt: null,
+      alertEndsAt: null
     };
   }
 
   function advanceQuestionTimer(now = Date.now()) {
-    if (questionTimer.status !== "running") return false;
     let changed = false;
-    let transitions = 0;
-    while (questionTimer.status === "running" && now >= questionTimer.phaseEndsAt && transitions < 500) {
-      transitions += 1;
+    if (questionTimer.status === "running" && now >= questionTimer.endsAt) {
+      const completedAt = questionTimer.endsAt;
       changed = true;
-      const previousEnd = questionTimer.phaseEndsAt;
-      if (questionTimer.phase === "question") {
-        questionTimer.phase = "ring";
-        questionTimer.remainingMs = QUESTION_RING_MS;
-        questionTimer.phaseEndsAt = previousEnd + QUESTION_RING_MS;
-      } else if (questionTimer.currentQuestion >= questionTimer.totalQuestions) {
-        questionTimer.status = "completed";
-        questionTimer.remainingMs = 0;
-        questionTimer.phaseEndsAt = null;
-        stopQuestionBell();
-      } else {
-        questionTimer.currentQuestion += 1;
-        questionTimer.phase = "question";
-        questionTimer.remainingMs = questionTimer.secondsPerQuestion * 1000;
-        questionTimer.phaseEndsAt = previousEnd + questionTimer.remainingMs;
-        stopQuestionBell();
-      }
+      questionTimer.status = "completed";
+      questionTimer.remainingMs = 0;
+      questionTimer.endsAt = null;
+      questionTimer.alertEndsAt = completedAt + QUESTION_RING_MS;
     }
-    if (changed) saveQuestionTimer();
-    if (questionTimer.status === "running" && questionTimer.phase === "ring") {
-      playQuestionBell(questionRemaining(now), questionTimer.phaseEndsAt);
-    } else if (bellPhaseEndAt !== null || bellNodes.length) {
+    if (questionTimer.status === "completed" && questionTimer.alertEndsAt > now) {
+      playQuestionBell(questionTimer.alertEndsAt - now, questionTimer.alertEndsAt);
+    } else if (questionTimer.alertEndsAt && questionTimer.alertEndsAt <= now) {
+      questionTimer.alertEndsAt = null;
+      changed = true;
+      stopQuestionBell();
+    } else if (questionTimer.status !== "completed" && (bellPhaseEndAt !== null || bellNodes.length)) {
       stopQuestionBell();
     }
+    if (changed) saveQuestionTimer();
     if (changed) syncWakeLock();
     return changed;
   }
@@ -316,28 +315,23 @@
 
   function renderQuestionTimer(now = Date.now()) {
     const remainingMs = questionRemaining(now);
-    const phaseDuration = questionTimer.phase === "ring" ? QUESTION_RING_MS : questionTimer.secondsPerQuestion * 1000;
-    const progress = questionTimer.status === "completed" ? 0 : clamp(remainingMs / phaseDuration, 0, 1);
+    const progress = questionTimer.status === "completed" ? 0 : clamp(remainingMs / questionTimer.totalDurationMs, 0, 1);
     const strokeOffset = (100 - progress * 100).toFixed(2);
-    const remainingQuestions = questionTimer.status === "completed" ? 0 : questionTimer.totalQuestions - questionTimer.currentQuestion + 1;
     const locked = questionTimer.status === "running" || questionTimer.status === "paused";
     const paused = questionTimer.status === "paused";
-    const ringing = questionTimer.phase === "ring" && questionTimer.status !== "completed";
-    let progressLabel = `第 ${questionTimer.currentQuestion} 题`;
-    let statusLabel = `第 ${questionTimer.currentQuestion} 题 / 共 ${questionTimer.totalQuestions} 题 · 含本题剩余 ${remainingQuestions} 题`;
-    let fullscreenStatus = paused ? "已暂停" : "本题剩余";
+    const minutesPerQuestion = String(questionTimer.secondsPerQuestion / 60).replace(/\.0$/, "");
+    const totalMinutes = questionTimer.totalDurationMs / 60000;
+    let progressLabel = paused ? "已暂停" : "总倒计时";
+    let statusLabel = `${questionTimer.totalQuestions} 题 × 每题 ${minutesPerQuestion} 分钟 · 共 ${totalMinutes} 分钟`;
+    let fullscreenStatus = paused ? "已暂停" : `${questionTimer.totalQuestions} 题 · 每题 ${minutesPerQuestion} 分钟`;
 
     if (questionTimer.status === "idle") {
-      progressLabel = "准备开始";
+      progressLabel = "总倒计时";
       fullscreenStatus = "准备开始";
     } else if (questionTimer.status === "completed") {
-      progressLabel = "全部完成";
-      statusLabel = `已完成全部 ${questionTimer.totalQuestions} 题`;
-      fullscreenStatus = "全部完成";
-    } else if (ringing) {
-      progressLabel = paused ? "换题铃声暂停" : "换题铃声";
-      statusLabel = `第 ${questionTimer.currentQuestion} 题计时结束 · 7 秒换题铃声`;
-      fullscreenStatus = paused ? "铃声已暂停" : (questionTimer.currentQuestion === questionTimer.totalQuestions ? "完成提示" : "即将进入下一题");
+      progressLabel = "时间到";
+      statusLabel = `${questionTimer.totalQuestions} 题的总计时已结束`;
+      fullscreenStatus = "本轮计时完成";
     }
 
     if (document.activeElement !== dom.questionCount) dom.questionCount.value = String(questionTimer.totalQuestions);
@@ -346,15 +340,13 @@
     dom.questionMinutes.disabled = locked;
     dom.questionProgress.style.strokeDashoffset = strokeOffset;
     dom.fullscreenQuestionProgress.style.strokeDashoffset = strokeOffset;
-    dom.questionProgressWrap.classList.toggle("ringing", ringing);
-    dom.fullscreenQuestionProgressWrap.classList.toggle("ringing", ringing);
     dom.questionProgressWrap.classList.toggle("completed", questionTimer.status === "completed");
     dom.fullscreenQuestionProgressWrap.classList.toggle("completed", questionTimer.status === "completed");
     dom.questionProgressLabel.textContent = progressLabel;
     dom.questionTimeLeft.textContent = questionCountdown(remainingMs);
     dom.questionRoundStatus.textContent = statusLabel;
-    dom.fullscreenQuestionRemaining.textContent = String(remainingQuestions);
-    dom.fullscreenQuestionLabel.textContent = ringing ? `第 ${questionTimer.currentQuestion} 题完成` : progressLabel;
+    dom.fullscreenQuestionRemaining.textContent = String(questionTimer.totalQuestions);
+    dom.fullscreenQuestionLabel.textContent = progressLabel;
     dom.fullscreenQuestionTime.textContent = questionCountdown(remainingMs);
     dom.fullscreenQuestionStatus.textContent = fullscreenStatus;
     dom.questionStart.hidden = locked;
@@ -377,10 +369,9 @@
     applyQuestionSettings();
     primeQuestionAudio().catch(() => null);
     questionTimer.status = "running";
-    questionTimer.phase = "question";
-    questionTimer.currentQuestion = 1;
-    questionTimer.remainingMs = questionTimer.secondsPerQuestion * 1000;
-    questionTimer.phaseEndsAt = Date.now() + questionTimer.remainingMs;
+    questionTimer.remainingMs = questionTimer.totalDurationMs;
+    questionTimer.endsAt = Date.now() + questionTimer.remainingMs;
+    questionTimer.alertEndsAt = null;
     saveQuestionTimer();
     renderQuestionTimer();
     syncWakeLock();
@@ -390,13 +381,12 @@
     if (questionTimer.status === "running") {
       questionTimer.remainingMs = questionRemaining();
       questionTimer.status = "paused";
-      questionTimer.phaseEndsAt = null;
+      questionTimer.endsAt = null;
       stopQuestionBell();
     } else if (questionTimer.status === "paused") {
       primeQuestionAudio().catch(() => null);
       questionTimer.status = "running";
-      questionTimer.phaseEndsAt = Date.now() + questionTimer.remainingMs;
-      if (questionTimer.phase === "ring") playQuestionBell(questionTimer.remainingMs, questionTimer.phaseEndsAt);
+      questionTimer.endsAt = Date.now() + questionTimer.remainingMs;
     } else {
       return;
     }
@@ -524,6 +514,7 @@
       return `
         <article class="study-record">
           <div>
+            <p class="record-subject">${escapeHTML(normalizeSubject(item.subject) || "未分类")}</p>
             <h3 class="record-duration">学习了 ${escapeHTML(formatDuration(item.durationMs))}</h3>
             <p class="record-time-range">${escapeHTML(timeLabel(item.start))} - ${escapeHTML(timeLabel(item.end, crossesDay))}</p>
           </div>
@@ -538,7 +529,8 @@
       typeof item.id === "string" && item.id.length > 0 &&
       Number.isFinite(item.start) && item.start > 0 &&
       Number.isFinite(item.end) && item.end >= item.start &&
-      Number.isFinite(item.durationMs) && item.durationMs >= 0;
+      Number.isFinite(item.durationMs) && item.durationMs >= 0 &&
+      (item.subject === undefined || (typeof item.subject === "string" && item.subject.trim().length <= 30));
   }
 
   function showRecordTransferStatus(message, isError = false) {
@@ -553,7 +545,8 @@
         id: item.id,
         start: item.start,
         end: item.end,
-        durationMs: item.durationMs
+        durationMs: item.durationMs,
+        subject: normalizeSubject(item.subject)
       }));
       const payload = {
         schema: "see-you-on-land-study-records",
@@ -602,12 +595,12 @@
       if (imported.some(item => !validStudyRecord(item))) throw new Error("文件中存在无效的学习记录");
 
       const ids = new Set(sessions.map(item => item.id));
-      const signatures = new Set(sessions.map(item => `${item.start}|${item.end}|${item.durationMs}`));
+      const signatures = new Set(sessions.map(item => `${item.start}|${item.end}|${item.durationMs}|${normalizeSubject(item.subject)}`));
       let added = 0;
       imported.forEach(item => {
-        const signature = `${item.start}|${item.end}|${item.durationMs}`;
+        const signature = `${item.start}|${item.end}|${item.durationMs}|${normalizeSubject(item.subject)}`;
         if (ids.has(item.id) || signatures.has(signature)) return;
-        sessions.push({ id: item.id, start: item.start, end: item.end, durationMs: item.durationMs });
+        sessions.push({ id: item.id, start: item.start, end: item.end, durationMs: item.durationMs, subject: normalizeSubject(item.subject) });
         ids.add(item.id);
         signatures.add(signature);
         added += 1;
@@ -630,23 +623,35 @@
 
   function renderTimerControls() {
     if (!activeSession) {
+      dom.studySubject.disabled = false;
       dom.activeElapsed.hidden = true;
       dom.timerActions.innerHTML = '<button type="button" class="study-start-button" id="start-study"><i data-lucide="play" aria-hidden="true"></i><span>开始学习！</span></button>';
     } else {
+      dom.studySubject.value = normalizeSubject(activeSession.subject) || "未分类";
+      dom.studySubject.disabled = true;
       dom.activeElapsed.hidden = false;
       const paused = activeSession.status === "paused";
       dom.timerActions.innerHTML = `
         <button type="button" class="pause-study-button" data-timer-action="${paused ? "resume" : "pause"}"><i data-lucide="${paused ? "play" : "pause"}" aria-hidden="true"></i><span>${paused ? "继续学习" : "暂停学习"}</span></button>
         <button type="button" class="stop-study-button" data-timer-action="stop"><i data-lucide="square" aria-hidden="true"></i><span>终止学习</span></button>`;
-      dom.activeElapsed.textContent = `${paused ? "已暂停" : "本次学习"} ${stopwatch(elapsedNow())}`;
+      dom.activeElapsed.textContent = `${normalizeSubject(activeSession.subject) || "未分类"} · ${paused ? "已暂停" : "本次学习"} ${stopwatch(elapsedNow())}`;
     }
     refreshIcons();
   }
 
   function startStudy() {
     if (activeSession) return;
+    const subject = normalizeSubject(dom.studySubject.value);
+    if (!subject) {
+      dom.studySubject.setCustomValidity("请选择或输入本次学习科目");
+      dom.studySubject.reportValidity();
+      dom.studySubject.focus();
+      return;
+    }
+    dom.studySubject.setCustomValidity("");
+    localStorage.setItem(LAST_SUBJECT_KEY, subject);
     const now = Date.now();
-    activeSession = { id: `active-${now}`, startedAt: now, resumedAt: now, accumulatedMs: 0, status: "running" };
+    activeSession = { id: `active-${now}`, subject, startedAt: now, resumedAt: now, accumulatedMs: 0, status: "running" };
     selectedDate = dayKey(now);
     saveActive();
     renderTimeline();
@@ -675,7 +680,7 @@
     if (!activeSession) return;
     const end = Date.now();
     const durationMs = elapsedNow();
-    sessions.push({ id: `study-${end}-${Math.random().toString(36).slice(2, 7)}`, start: activeSession.startedAt, end, durationMs });
+    sessions.push({ id: `study-${end}-${Math.random().toString(36).slice(2, 7)}`, subject: normalizeSubject(activeSession.subject), start: activeSession.startedAt, end, durationMs });
     selectedDate = dayKey(activeSession.startedAt);
     activeSession = null;
     saveActive();
@@ -691,7 +696,7 @@
     const time = `${pad(now.getHours())}:${pad(now.getMinutes())}${showSeconds ? `:${pad(now.getSeconds())}` : ""}`;
     dom.liveClock.textContent = time;
     dom.fullscreenTime.textContent = time;
-    if (activeSession) dom.activeElapsed.textContent = `${activeSession.status === "paused" ? "已暂停" : "本次学习"} ${stopwatch(elapsedNow())}`;
+    if (activeSession) dom.activeElapsed.textContent = `${normalizeSubject(activeSession.subject) || "未分类"} · ${activeSession.status === "paused" ? "已暂停" : "本次学习"} ${stopwatch(elapsedNow())}`;
   }
 
   function isFullscreen() {
@@ -839,6 +844,7 @@
     const record = sessions.find(item => item.id === recordId);
     if (!record) return;
     dom.editId.value = record.id;
+    dom.editSubject.value = normalizeSubject(record.subject) || "未分类";
     dom.editStart.value = inputDateTime(record.start);
     dom.editEnd.value = inputDateTime(record.end);
     dom.editMinutes.value = Math.max(1, Math.round(record.durationMs / 60000));
@@ -855,13 +861,15 @@
   function saveEdit(event) {
     event.preventDefault();
     const record = sessions.find(item => item.id === dom.editId.value);
+    const subject = normalizeSubject(dom.editSubject.value);
     const start = new Date(dom.editStart.value).getTime();
     const end = new Date(dom.editEnd.value).getTime();
     const minutes = Number(dom.editMinutes.value);
-    if (!record || !Number.isFinite(start) || !Number.isFinite(end) || end <= start || !Number.isFinite(minutes) || minutes < 1) {
-      dom.formError.textContent = "请检查开始时间、结束时间和有效学习分钟。";
+    if (!record || !subject || !Number.isFinite(start) || !Number.isFinite(end) || end <= start || !Number.isFinite(minutes) || minutes < 1) {
+      dom.formError.textContent = "请检查学习科目、开始时间、结束时间和有效学习分钟。";
       return;
     }
+    record.subject = subject;
     record.start = start;
     record.end = end;
     record.durationMs = minutes * 60000;
@@ -1077,10 +1085,16 @@
   dom.recordExport.addEventListener("click", exportStudyRecords);
   dom.recordImport.addEventListener("click", () => dom.recordFile.click());
   dom.recordFile.addEventListener("change", () => importStudyRecords(dom.recordFile.files[0]));
+  dom.studySubject.addEventListener("input", () => {
+    dom.studySubject.setCustomValidity("");
+    const subject = normalizeSubject(dom.studySubject.value);
+    if (subject && !activeSession) localStorage.setItem(LAST_SUBJECT_KEY, subject);
+  });
   window.addEventListener("pagehide", stopQuestionBell);
 
   if (!Array.isArray(sessions)) sessions = [];
   if (activeSession && (!activeSession.startedAt || !["running", "paused"].includes(activeSession.status))) activeSession = null;
+  dom.studySubject.value = normalizeSubject(activeSession?.subject || localStorage.getItem(LAST_SUBJECT_KEY));
   advanceQuestionTimer();
   renderTimeline();
   renderRecords();

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#ffffff">
   <title>暑假时政学习清单</title>
-  <link rel="stylesheet" href="clock.css?v=20260711-2">
+  <link rel="stylesheet" href="clock.css?v=20260815-1">
   <style>
     :root {
       --bg: #ffffff;
@@ -1120,6 +1120,10 @@
               <article class="live-clock-card clock-mode-card" data-clock-mode="clock" aria-label="当前时间与学习计时器">
                 <button type="button" class="live-clock" id="live-clock" aria-label="切换时间显示格式">00:00</button>
                 <p class="clock-format-hint">当前时间</p>
+                <label class="study-subject-picker" for="study-subject">
+                  <span>本次学习科目</span>
+                  <input id="study-subject" type="text" list="study-subject-options" maxlength="30" autocomplete="off" placeholder="请选择或输入科目" required>
+                </label>
                 <div class="active-elapsed" id="active-elapsed" hidden>本次学习 00:00</div>
                 <div class="timer-actions" id="timer-actions">
                   <button type="button" class="study-start-button" id="start-study"><i data-lucide="play" aria-hidden="true"></i><span>开始学习！</span></button>
@@ -1129,9 +1133,9 @@
                 </button>
               </article>
 
-              <article class="question-timer-card clock-mode-card" data-clock-mode="questions" aria-label="做题循环计时器">
+              <article class="question-timer-card clock-mode-card" data-clock-mode="questions" aria-label="做题总倒计时器">
                 <header class="question-card-header">
-                  <div><p class="eyebrow">QUESTION TIMER</p><h2>做题计时</h2></div>
+                  <div><p class="eyebrow">QUESTION TIMER</p><h2>做题总计时</h2></div>
                   <div class="question-card-tools">
                     <button type="button" class="icon-button" id="reset-question-timer" title="重新设置" aria-label="重新设置做题计时"><i data-lucide="rotate-ccw" aria-hidden="true"></i></button>
                     <button type="button" class="icon-button" id="pause-question-timer" title="暂停做题计时" aria-label="暂停做题计时" disabled><i data-lucide="pause" aria-hidden="true"></i></button>
@@ -1146,9 +1150,9 @@
                     <circle class="question-progress-track" cx="60" cy="60" r="52"></circle>
                     <circle class="question-progress-value" id="question-progress-value" cx="60" cy="60" r="52" pathLength="100"></circle>
                   </svg>
-                  <div class="question-progress-copy"><span id="question-progress-label">准备开始</span><strong id="question-time-left">03:00</strong></div>
+                  <div class="question-progress-copy"><span id="question-progress-label">总倒计时</span><strong id="question-time-left">02:00:00</strong></div>
                 </div>
-                <p class="question-round-status" id="question-round-status" aria-live="polite">第 1 题 / 共 40 题 · 含本题剩余 40 题</p>
+                <p class="question-round-status" id="question-round-status" aria-live="polite">40 题 × 每题 3 分钟 · 共 120 分钟</p>
                 <button type="button" class="question-start-button" id="start-question-timer"><i data-lucide="play" aria-hidden="true"></i><span>开始做题</span></button>
                 <button type="button" class="clock-fullscreen-enter question-fullscreen-enter" id="enter-question-fullscreen" title="进入全屏做题计时" aria-label="进入全屏做题计时">
                   <i data-lucide="maximize-2" aria-hidden="true"></i>
@@ -1172,6 +1176,22 @@
             </div>
           </div>
           <input class="study-record-file" id="study-record-file" type="file" accept="application/json,.json" aria-label="选择学习记录文件">
+          <datalist id="study-subject-options">
+            <option value="政治理论"></option>
+            <option value="常识判断"></option>
+            <option value="言语理解与表达"></option>
+            <option value="选词填空"></option>
+            <option value="片段阅读"></option>
+            <option value="语句表达"></option>
+            <option value="数量关系"></option>
+            <option value="数字推理"></option>
+            <option value="判断推理"></option>
+            <option value="图形推理"></option>
+            <option value="逻辑判断"></option>
+            <option value="科学推理"></option>
+            <option value="资料分析"></option>
+            <option value="申论"></option>
+          </datalist>
           <p class="study-record-transfer-status" id="study-record-transfer-status" role="status" aria-live="polite" hidden></p>
           <div class="study-record-list" id="study-record-list"></div>
         </section>
@@ -1243,6 +1263,7 @@
         </header>
         <form id="timer-edit-form">
           <input type="hidden" id="edit-record-id">
+          <label>学习科目<input type="text" id="edit-record-subject" list="study-subject-options" maxlength="30" autocomplete="off" required></label>
           <label>开始时间<input type="datetime-local" id="edit-record-start" required></label>
           <label>结束时间<input type="datetime-local" id="edit-record-end" required></label>
           <label>有效学习分钟<input type="number" id="edit-record-minutes" min="1" max="1440" step="1" required></label>
@@ -1262,7 +1283,7 @@
             <button type="button" class="fullscreen-clock-time" id="fullscreen-clock-time" aria-label="切换时间显示格式">00:00</button>
           </section>
           <section class="fullscreen-mode-slide fullscreen-question-slide" data-fullscreen-mode="questions">
-            <div class="fullscreen-question-remaining"><strong id="fullscreen-question-remaining">40</strong><span>剩余题目<br>含本题</span></div>
+            <div class="fullscreen-question-remaining"><strong id="fullscreen-question-remaining">40</strong><span>题目总数</span></div>
             <div class="fullscreen-question-tools">
               <button type="button" id="fullscreen-reset-question" title="重新设置" aria-label="重新设置做题计时"><i data-lucide="rotate-ccw" aria-hidden="true"></i></button>
               <button type="button" id="fullscreen-pause-question" title="暂停做题计时" aria-label="暂停做题计时" disabled><i data-lucide="pause" aria-hidden="true"></i></button>
@@ -1272,7 +1293,7 @@
                 <circle class="question-progress-track" cx="60" cy="60" r="52"></circle>
                 <circle class="question-progress-value" id="fullscreen-question-progress-value" cx="60" cy="60" r="52" pathLength="100"></circle>
               </svg>
-              <div><span id="fullscreen-question-label">第 1 题</span><strong id="fullscreen-question-time">03:00</strong><small id="fullscreen-question-status">准备开始</small></div>
+              <div><span id="fullscreen-question-label">总倒计时</span><strong id="fullscreen-question-time">02:00:00</strong><small id="fullscreen-question-status">准备开始</small></div>
             </div>
           </section>
         </div>
@@ -1709,7 +1730,7 @@
       refreshIcons();
     })();
   </script>
-  <script src="clock.js?v=20260803-1"></script>
-  <script src="backup.js?v=20260714-1"></script>
+  <script src="clock.js?v=20260815-1"></script>
+  <script src="backup.js?v=20260815-1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Changes
- replace per-question cycles with one total countdown computed from question count and minutes per question
- add preset and custom study subjects to active sessions and saved records
- preserve subjects in editing, record import/export, and full backups
- update fullscreen timer labels and responsive styles

## Validation
- node --check clock.js backup.js
- git diff --check
- browser-tested at 390x844 and 768x1024
- verified start/stop, subject editing, pause stability, and fullscreen countdown
- no browser console errors