### PR TITLE
Fix timer fit and subject selection

### DIFF
--- a/clock.css
+++ b/clock.css
@@ -180,6 +180,7 @@
 
 .question-progress-wrap {
   position: relative;
+  container-type: inline-size;
   width: 178px;
   height: 178px;
   margin: 18px auto 0;
@@ -224,7 +225,11 @@
   font-weight: 400;
   font-variant-numeric: tabular-nums;
   line-height: 1;
+  white-space: nowrap;
 }
+
+.question-progress-copy strong.countdown-long { font-size: 26px; font-size: 15cqi; }
+.question-progress-copy strong.countdown-very-long { font-size: 23px; font-size: 13cqi; }
 
 .question-round-status {
   margin-top: 11px;
@@ -412,6 +417,7 @@
 
 .fullscreen-question-progress {
   position: relative;
+  container-type: inline-size;
   width: clamp(220px, 45vmin, 430px);
   height: clamp(220px, 45vmin, 430px);
 }
@@ -436,7 +442,10 @@
   font-weight: 400;
   line-height: 1;
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
+.fullscreen-question-progress strong.countdown-long { font-size: 64px; font-size: 15cqi; }
+.fullscreen-question-progress strong.countdown-very-long { font-size: 54px; font-size: 13cqi; }
 .fullscreen-question-progress small { margin-top: 12px; color: #b8bdbc; font-size: clamp(13px, 1.7vw, 18px); }
 
 .fullscreen-mode-dots {
@@ -510,6 +519,15 @@ body.clock-fullscreen-active { overflow: hidden; background: #000; }
   text-align: left;
 }
 
+.study-subject-picker label { white-space: nowrap; }
+
+.study-subject-control {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.study-subject-picker select,
 .study-subject-picker input {
   width: 100%;
   min-height: 46px;
@@ -522,10 +540,19 @@ body.clock-fullscreen-active { overflow: hidden; background: #000; }
   font-size: 16px;
 }
 
+.study-subject-picker select {
+  appearance: auto;
+  cursor: pointer;
+}
+
+.study-subject-picker select:disabled,
 .study-subject-picker input:disabled {
   background: var(--surface-strong);
   color: var(--muted);
+  cursor: default;
 }
+
+.study-subject-picker input[hidden] { display: none; }
 
 .active-elapsed {
   width: fit-content;
@@ -813,7 +840,9 @@ body.clock-fullscreen-active { overflow: hidden; background: #000; }
 
 .timer-dialog form { display: grid; gap: 15px; margin-top: 20px; }
 .timer-dialog label { display: grid; gap: 7px; color: var(--muted); font-size: 14px; }
-.timer-dialog input {
+.timer-dialog label[hidden] { display: none; }
+.timer-dialog input,
+.timer-dialog select {
   width: 100%;
   min-height: 46px;
   padding: 10px 12px;
@@ -823,6 +852,8 @@ body.clock-fullscreen-active { overflow: hidden; background: #000; }
   color: var(--ink);
   font-size: 16px;
 }
+
+.timer-dialog select { appearance: auto; }
 
 @media (max-width: 360px) {
   .study-subject-picker { grid-template-columns: 1fr; gap: 7px; }

--- a/clock.js
+++ b/clock.js
@@ -6,6 +6,11 @@
   const CLOCK_FORMAT_KEY = "summer-politics-clock-seconds-v1";
   const QUESTION_TIMER_KEY = "summer-politics-question-timer-v1";
   const LAST_SUBJECT_KEY = "summer-politics-last-study-subject-v1";
+  const CUSTOM_SUBJECT_VALUE = "__custom__";
+  const PRESET_SUBJECTS = new Set([
+    "政治理论", "常识判断", "言语理解与表达", "选词填空", "片段阅读", "语句表达",
+    "数量关系", "数字推理", "判断推理", "图形推理", "逻辑判断", "科学推理", "资料分析", "申论"
+  ]);
   const QUESTION_RING_MS = 7000;
   const DAY_MS = 86400000;
 
@@ -58,11 +63,14 @@
     editForm: document.getElementById("timer-edit-form"),
     editId: document.getElementById("edit-record-id"),
     editSubject: document.getElementById("edit-record-subject"),
+    editCustomSubject: document.getElementById("edit-custom-subject"),
+    editCustomSubjectWrap: document.getElementById("edit-custom-subject-wrap"),
     editStart: document.getElementById("edit-record-start"),
     editEnd: document.getElementById("edit-record-end"),
     editMinutes: document.getElementById("edit-record-minutes"),
     formError: document.getElementById("timer-form-error"),
     studySubject: document.getElementById("study-subject"),
+    studyCustomSubject: document.getElementById("study-custom-subject"),
     questionCount: document.getElementById("question-count"),
     questionMinutes: document.getElementById("question-minutes"),
     questionProgressWrap: document.getElementById("question-progress-wrap"),
@@ -118,6 +126,50 @@
 
   function normalizeSubject(value) {
     return String(value ?? "").trim().replace(/\s+/g, " ").slice(0, 30);
+  }
+
+  function selectedSubject(select, customInput) {
+    return select.value === CUSTOM_SUBJECT_VALUE ? normalizeSubject(customInput.value) : normalizeSubject(select.value);
+  }
+
+  function toggleCustomSubject(select, customInput, customWrap = null, focus = false) {
+    const custom = select.value === CUSTOM_SUBJECT_VALUE;
+    if (customWrap) customWrap.hidden = !custom;
+    else customInput.hidden = !custom;
+    customInput.required = custom;
+    if (custom && focus) requestAnimationFrame(() => customInput.focus());
+  }
+
+  function setSubjectControls(select, customInput, subject, customWrap = null) {
+    const normalized = normalizeSubject(subject);
+    if (!normalized) {
+      select.value = "";
+      customInput.value = "";
+    } else if (PRESET_SUBJECTS.has(normalized)) {
+      select.value = normalized;
+      customInput.value = "";
+    } else {
+      select.value = CUSTOM_SUBJECT_VALUE;
+      customInput.value = normalized;
+    }
+    toggleCustomSubject(select, customInput, customWrap);
+  }
+
+  function validateSubjectControls(select, customInput) {
+    select.setCustomValidity("");
+    customInput.setCustomValidity("");
+    if (!select.value) {
+      select.setCustomValidity("请选择本次学习科目");
+      select.reportValidity();
+      return "";
+    }
+    const subject = selectedSubject(select, customInput);
+    if (!subject) {
+      customInput.setCustomValidity("请输入自定义学习科目");
+      customInput.reportValidity();
+      return "";
+    }
+    return subject;
   }
 
   function saveSessions() {
@@ -342,12 +394,19 @@
     dom.fullscreenQuestionProgress.style.strokeDashoffset = strokeOffset;
     dom.questionProgressWrap.classList.toggle("completed", questionTimer.status === "completed");
     dom.fullscreenQuestionProgressWrap.classList.toggle("completed", questionTimer.status === "completed");
+    const countdownText = questionCountdown(remainingMs);
+    const veryLongCountdown = countdownText.length > 8;
+    const longCountdown = countdownText.length > 5;
     dom.questionProgressLabel.textContent = progressLabel;
-    dom.questionTimeLeft.textContent = questionCountdown(remainingMs);
+    dom.questionTimeLeft.textContent = countdownText;
+    dom.questionTimeLeft.classList.toggle("countdown-long", longCountdown);
+    dom.questionTimeLeft.classList.toggle("countdown-very-long", veryLongCountdown);
     dom.questionRoundStatus.textContent = statusLabel;
     dom.fullscreenQuestionRemaining.textContent = String(questionTimer.totalQuestions);
     dom.fullscreenQuestionLabel.textContent = progressLabel;
-    dom.fullscreenQuestionTime.textContent = questionCountdown(remainingMs);
+    dom.fullscreenQuestionTime.textContent = countdownText;
+    dom.fullscreenQuestionTime.classList.toggle("countdown-long", longCountdown);
+    dom.fullscreenQuestionTime.classList.toggle("countdown-very-long", veryLongCountdown);
     dom.fullscreenQuestionStatus.textContent = fullscreenStatus;
     dom.questionStart.hidden = locked;
     dom.questionStart.querySelector("span").textContent = questionTimer.status === "completed" ? "再来一轮" : "开始做题";
@@ -624,11 +683,13 @@
   function renderTimerControls() {
     if (!activeSession) {
       dom.studySubject.disabled = false;
+      dom.studyCustomSubject.disabled = false;
       dom.activeElapsed.hidden = true;
       dom.timerActions.innerHTML = '<button type="button" class="study-start-button" id="start-study"><i data-lucide="play" aria-hidden="true"></i><span>开始学习！</span></button>';
     } else {
-      dom.studySubject.value = normalizeSubject(activeSession.subject) || "未分类";
+      setSubjectControls(dom.studySubject, dom.studyCustomSubject, normalizeSubject(activeSession.subject) || "未分类");
       dom.studySubject.disabled = true;
+      dom.studyCustomSubject.disabled = true;
       dom.activeElapsed.hidden = false;
       const paused = activeSession.status === "paused";
       dom.timerActions.innerHTML = `
@@ -641,14 +702,8 @@
 
   function startStudy() {
     if (activeSession) return;
-    const subject = normalizeSubject(dom.studySubject.value);
-    if (!subject) {
-      dom.studySubject.setCustomValidity("请选择或输入本次学习科目");
-      dom.studySubject.reportValidity();
-      dom.studySubject.focus();
-      return;
-    }
-    dom.studySubject.setCustomValidity("");
+    const subject = validateSubjectControls(dom.studySubject, dom.studyCustomSubject);
+    if (!subject) return;
     localStorage.setItem(LAST_SUBJECT_KEY, subject);
     const now = Date.now();
     activeSession = { id: `active-${now}`, subject, startedAt: now, resumedAt: now, accumulatedMs: 0, status: "running" };
@@ -844,7 +899,7 @@
     const record = sessions.find(item => item.id === recordId);
     if (!record) return;
     dom.editId.value = record.id;
-    dom.editSubject.value = normalizeSubject(record.subject) || "未分类";
+    setSubjectControls(dom.editSubject, dom.editCustomSubject, normalizeSubject(record.subject) || "未分类", dom.editCustomSubjectWrap);
     dom.editStart.value = inputDateTime(record.start);
     dom.editEnd.value = inputDateTime(record.end);
     dom.editMinutes.value = Math.max(1, Math.round(record.durationMs / 60000));
@@ -861,7 +916,7 @@
   function saveEdit(event) {
     event.preventDefault();
     const record = sessions.find(item => item.id === dom.editId.value);
-    const subject = normalizeSubject(dom.editSubject.value);
+    const subject = validateSubjectControls(dom.editSubject, dom.editCustomSubject);
     const start = new Date(dom.editStart.value).getTime();
     const end = new Date(dom.editEnd.value).getTime();
     const minutes = Number(dom.editMinutes.value);
@@ -1085,16 +1140,27 @@
   dom.recordExport.addEventListener("click", exportStudyRecords);
   dom.recordImport.addEventListener("click", () => dom.recordFile.click());
   dom.recordFile.addEventListener("change", () => importStudyRecords(dom.recordFile.files[0]));
-  dom.studySubject.addEventListener("input", () => {
+  dom.studySubject.addEventListener("change", () => {
     dom.studySubject.setCustomValidity("");
-    const subject = normalizeSubject(dom.studySubject.value);
+    toggleCustomSubject(dom.studySubject, dom.studyCustomSubject, null, true);
+    const subject = selectedSubject(dom.studySubject, dom.studyCustomSubject);
     if (subject && !activeSession) localStorage.setItem(LAST_SUBJECT_KEY, subject);
   });
+  dom.studyCustomSubject.addEventListener("input", () => {
+    dom.studyCustomSubject.setCustomValidity("");
+    const subject = selectedSubject(dom.studySubject, dom.studyCustomSubject);
+    if (subject && !activeSession) localStorage.setItem(LAST_SUBJECT_KEY, subject);
+  });
+  dom.editSubject.addEventListener("change", () => {
+    dom.editSubject.setCustomValidity("");
+    toggleCustomSubject(dom.editSubject, dom.editCustomSubject, dom.editCustomSubjectWrap, true);
+  });
+  dom.editCustomSubject.addEventListener("input", () => dom.editCustomSubject.setCustomValidity(""));
   window.addEventListener("pagehide", stopQuestionBell);
 
   if (!Array.isArray(sessions)) sessions = [];
   if (activeSession && (!activeSession.startedAt || !["running", "paused"].includes(activeSession.status))) activeSession = null;
-  dom.studySubject.value = normalizeSubject(activeSession?.subject || localStorage.getItem(LAST_SUBJECT_KEY));
+  setSubjectControls(dom.studySubject, dom.studyCustomSubject, activeSession?.subject || localStorage.getItem(LAST_SUBJECT_KEY));
   advanceQuestionTimer();
   renderTimeline();
   renderRecords();

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#ffffff">
   <title>暑假时政学习清单</title>
-  <link rel="stylesheet" href="clock.css?v=20260815-1">
+  <link rel="stylesheet" href="clock.css?v=20260815-2">
   <style>
     :root {
       --bg: #ffffff;
@@ -1120,10 +1120,30 @@
               <article class="live-clock-card clock-mode-card" data-clock-mode="clock" aria-label="当前时间与学习计时器">
                 <button type="button" class="live-clock" id="live-clock" aria-label="切换时间显示格式">00:00</button>
                 <p class="clock-format-hint">当前时间</p>
-                <label class="study-subject-picker" for="study-subject">
-                  <span>本次学习科目</span>
-                  <input id="study-subject" type="text" list="study-subject-options" maxlength="30" autocomplete="off" placeholder="请选择或输入科目" required>
-                </label>
+                <div class="study-subject-picker">
+                  <label for="study-subject">本次学习科目</label>
+                  <div class="study-subject-control">
+                    <select id="study-subject" required>
+                      <option value="">请选择科目</option>
+                      <option value="政治理论">政治理论</option>
+                      <option value="常识判断">常识判断</option>
+                      <option value="言语理解与表达">言语理解与表达</option>
+                      <option value="选词填空">选词填空</option>
+                      <option value="片段阅读">片段阅读</option>
+                      <option value="语句表达">语句表达</option>
+                      <option value="数量关系">数量关系</option>
+                      <option value="数字推理">数字推理</option>
+                      <option value="判断推理">判断推理</option>
+                      <option value="图形推理">图形推理</option>
+                      <option value="逻辑判断">逻辑判断</option>
+                      <option value="科学推理">科学推理</option>
+                      <option value="资料分析">资料分析</option>
+                      <option value="申论">申论</option>
+                      <option value="__custom__">其他（自定义）</option>
+                    </select>
+                    <input id="study-custom-subject" type="text" maxlength="30" autocomplete="off" placeholder="输入自定义科目" aria-label="自定义学习科目" hidden>
+                  </div>
+                </div>
                 <div class="active-elapsed" id="active-elapsed" hidden>本次学习 00:00</div>
                 <div class="timer-actions" id="timer-actions">
                   <button type="button" class="study-start-button" id="start-study"><i data-lucide="play" aria-hidden="true"></i><span>开始学习！</span></button>
@@ -1176,22 +1196,6 @@
             </div>
           </div>
           <input class="study-record-file" id="study-record-file" type="file" accept="application/json,.json" aria-label="选择学习记录文件">
-          <datalist id="study-subject-options">
-            <option value="政治理论"></option>
-            <option value="常识判断"></option>
-            <option value="言语理解与表达"></option>
-            <option value="选词填空"></option>
-            <option value="片段阅读"></option>
-            <option value="语句表达"></option>
-            <option value="数量关系"></option>
-            <option value="数字推理"></option>
-            <option value="判断推理"></option>
-            <option value="图形推理"></option>
-            <option value="逻辑判断"></option>
-            <option value="科学推理"></option>
-            <option value="资料分析"></option>
-            <option value="申论"></option>
-          </datalist>
           <p class="study-record-transfer-status" id="study-record-transfer-status" role="status" aria-live="polite" hidden></p>
           <div class="study-record-list" id="study-record-list"></div>
         </section>
@@ -1263,7 +1267,27 @@
         </header>
         <form id="timer-edit-form">
           <input type="hidden" id="edit-record-id">
-          <label>学习科目<input type="text" id="edit-record-subject" list="study-subject-options" maxlength="30" autocomplete="off" required></label>
+          <label>学习科目
+            <select id="edit-record-subject" required>
+              <option value="">请选择科目</option>
+              <option value="政治理论">政治理论</option>
+              <option value="常识判断">常识判断</option>
+              <option value="言语理解与表达">言语理解与表达</option>
+              <option value="选词填空">选词填空</option>
+              <option value="片段阅读">片段阅读</option>
+              <option value="语句表达">语句表达</option>
+              <option value="数量关系">数量关系</option>
+              <option value="数字推理">数字推理</option>
+              <option value="判断推理">判断推理</option>
+              <option value="图形推理">图形推理</option>
+              <option value="逻辑判断">逻辑判断</option>
+              <option value="科学推理">科学推理</option>
+              <option value="资料分析">资料分析</option>
+              <option value="申论">申论</option>
+              <option value="__custom__">其他（自定义）</option>
+            </select>
+          </label>
+          <label id="edit-custom-subject-wrap" hidden>自定义科目<input type="text" id="edit-custom-subject" maxlength="30" autocomplete="off"></label>
           <label>开始时间<input type="datetime-local" id="edit-record-start" required></label>
           <label>结束时间<input type="datetime-local" id="edit-record-end" required></label>
           <label>有效学习分钟<input type="number" id="edit-record-minutes" min="1" max="1440" step="1" required></label>
@@ -1730,7 +1754,7 @@
       refreshIcons();
     })();
   </script>
-  <script src="clock.js?v=20260815-1"></script>
+  <script src="clock.js?v=20260815-2"></script>
   <script src="backup.js?v=20260815-1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Changes
- keep long total countdown values fully inside the progress ring
- replace the editable datalist with a native subject dropdown
- show a text field only when Other (custom) is selected
- apply the same subject controls to record editing

## Validation
- tested at 320x844 with no horizontal overflow
- verified 02:00:00 and maximum 200:00:00 fit inside the ring
- verified preset and custom subject save flows
- verified edit dialog preset/custom switching
- node syntax and diff checks pass; no browser console errors