### PR TITLE
Simplify OpenRouter settings and fix chat requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <meta name="theme-color" content="#ffffff">
   <title>暑假时政学习清单</title>
   <link rel="stylesheet" href="clock.css?v=20260815-2">
-  <link rel="stylesheet" href="search.css?v=20260821-1">
+  <link rel="stylesheet" href="search.css?v=20260821-2">
   <style>
     :root {
       --bg: #ffffff;
@@ -1269,11 +1269,6 @@
               <i data-lucide="image-up" aria-hidden="true"></i>
             </button>
           </div>
-          <button type="button" class="solver-model-button" id="solver-model-button" aria-label="选择搜题模型">
-            <i data-lucide="bot" aria-hidden="true"></i>
-            <span id="solver-model-label">配置模型</span>
-            <i data-lucide="chevron-down" aria-hidden="true"></i>
-          </button>
           <button type="submit" class="solver-send-button" id="solver-send" title="发送" aria-label="发送问题">
             <i data-lucide="arrow-up" aria-hidden="true"></i>
           </button>
@@ -1373,18 +1368,8 @@
           </label>
           <p class="solver-settings-note">密钥仅保存在当前浏览器，不会写入网站备份。<a href="https://openrouter.ai/settings/keys" target="_blank" rel="noopener noreferrer">获取 API Key</a></p>
           <label class="solver-settings-field">
-            <span>多模态模型</span>
-            <select id="solver-model-select" required>
-              <option value="google/gemini-3.6-flash">Google · Gemini 3.6 Flash</option>
-              <option value="openai/gpt-5.6-luna">OpenAI · GPT-5.6 Luna</option>
-              <option value="anthropic/claude-sonnet-5">Anthropic · Claude Sonnet 5</option>
-              <option value="google/gemini-2.5-flash-lite">Google · Gemini 2.5 Flash Lite</option>
-              <option value="__custom__">其他模型 ID</option>
-            </select>
-          </label>
-          <label class="solver-settings-field" id="solver-custom-model-wrap" hidden>
             <span>模型 ID</span>
-            <input type="text" id="solver-custom-model" maxlength="120" autocomplete="off" spellcheck="false" placeholder="例如 google/gemini-3.6-flash">
+            <input type="text" id="solver-model-input" maxlength="120" autocomplete="off" spellcheck="false" placeholder="例如 google/gemini-3.6-flash" required>
           </label>
           <p class="solver-settings-status" id="solver-settings-status" role="status" aria-live="polite"></p>
           <div class="solver-settings-actions">
@@ -1853,6 +1838,6 @@
   </script>
   <script src="clock.js?v=20260815-2"></script>
   <script src="backup.js?v=20260815-1"></script>
-  <script src="search.js?v=20260821-1"></script>
+  <script src="search.js?v=20260821-2"></script>
 </body>
 </html>

--- a/search.css
+++ b/search.css
@@ -289,9 +289,9 @@
 .solver-preview-remove .lucide { width: 14px; height: 14px; }
 
 .solver-composer-actions {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 9px;
 }
 
@@ -315,29 +315,6 @@
 }
 
 .solver-icon-button:hover { background: var(--surface); color: var(--ink); }
-
-.solver-model-button {
-  min-width: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 0 8px;
-  border: 0;
-  background: transparent;
-  color: var(--muted);
-  font-size: 13px;
-  cursor: pointer;
-}
-
-.solver-model-button span {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.solver-model-button .lucide { flex: 0 0 auto; width: 16px; height: 16px; }
 
 .solver-send-button {
   border: 1px solid var(--ink);
@@ -521,7 +498,6 @@
   .solver-welcome h2 { font-size: 30px; }
   .solver-messages { padding-left: 16px; padding-right: 16px; }
   .solver-composer { width: calc(100% - 24px); padding: 12px; }
-  .solver-model-button { padding: 0 4px; }
 }
 
 @media (min-width: 600px) {

--- a/search.js
+++ b/search.js
@@ -3,8 +3,6 @@
 
   const SETTINGS_KEY = "summer-politics-openrouter-settings-v1";
   const CHAT_ENDPOINT = "https://openrouter.ai/api/v1/chat/completions";
-  const MODELS_ENDPOINT = "https://openrouter.ai/api/v1/models?input_modalities=image&output_modalities=text&sort=most-popular";
-  const CUSTOM_MODEL_VALUE = "__custom__";
   const DEFAULT_MODEL = "google/gemini-3.6-flash";
   const MAX_IMAGES = 4;
   const MAX_FILE_BYTES = 12 * 1024 * 1024;
@@ -28,8 +26,6 @@
     uploadButton: document.getElementById("solver-upload"),
     cameraInput: document.getElementById("solver-camera-input"),
     uploadInput: document.getElementById("solver-upload-input"),
-    modelButton: document.getElementById("solver-model-button"),
-    modelLabel: document.getElementById("solver-model-label"),
     sendButton: document.getElementById("solver-send"),
     status: document.getElementById("solver-status"),
     settingsButton: document.getElementById("open-solver-settings"),
@@ -38,9 +34,7 @@
     settingsForm: document.getElementById("solver-settings-form"),
     apiKey: document.getElementById("solver-api-key"),
     apiKeyToggle: document.getElementById("toggle-solver-api-key"),
-    modelSelect: document.getElementById("solver-model-select"),
-    customModelWrap: document.getElementById("solver-custom-model-wrap"),
-    customModel: document.getElementById("solver-custom-model"),
+    modelInput: document.getElementById("solver-model-input"),
     settingsStatus: document.getElementById("solver-settings-status"),
     testConnection: document.getElementById("test-solver-connection"),
     clearChat: document.getElementById("clear-solver-chat")
@@ -53,19 +47,15 @@
   let conversation = [];
   let requestController = null;
   let sending = false;
-  let visionModels = [];
-  let modelsLoaded = false;
-
   function loadSettings() {
     try {
       const value = JSON.parse(localStorage.getItem(SETTINGS_KEY));
       return {
         apiKey: typeof value?.apiKey === "string" ? value.apiKey.trim() : "",
-        model: typeof value?.model === "string" && value.model.trim() ? value.model.trim() : DEFAULT_MODEL,
-        modelName: typeof value?.modelName === "string" ? value.modelName.trim() : ""
+        model: typeof value?.model === "string" && value.model.trim() ? value.model.trim() : DEFAULT_MODEL
       };
     } catch {
-      return { apiKey: "", model: DEFAULT_MODEL, modelName: "" };
+      return { apiKey: "", model: DEFAULT_MODEL };
     }
   }
 
@@ -94,103 +84,21 @@
   }
 
   function currentModelLabel() {
-    if (settings.modelName) return settings.modelName;
-    const model = visionModels.find(item => item.id === settings.model);
-    if (model?.name) return model.name;
-    const fallback = Array.from(dom.modelSelect.options).find(option => option.value === settings.model);
-    return fallback?.textContent || settings.model.split("/").pop() || "配置模型";
+    return settings.model.split("/").pop() || "解题助手";
   }
 
   function renderConfigurationState() {
     dom.settingsDot.classList.toggle("configured", Boolean(settings.apiKey && settings.model));
-    dom.modelLabel.textContent = currentModelLabel();
-    dom.modelLabel.title = settings.model;
-  }
-
-  function selectedModelFromForm() {
-    return dom.modelSelect.value === CUSTOM_MODEL_VALUE
-      ? normalizeModel(dom.customModel.value)
-      : normalizeModel(dom.modelSelect.value);
-  }
-
-  function toggleCustomModel(focus = false) {
-    const custom = dom.modelSelect.value === CUSTOM_MODEL_VALUE;
-    dom.customModelWrap.hidden = !custom;
-    dom.customModel.required = custom;
-    if (custom && focus) requestAnimationFrame(() => dom.customModel.focus());
-  }
-
-  function setModelControls(model) {
-    const normalized = normalizeModel(model) || DEFAULT_MODEL;
-    const optionExists = Array.from(dom.modelSelect.options).some(option => option.value === normalized);
-    if (optionExists) {
-      dom.modelSelect.value = normalized;
-      dom.customModel.value = "";
-    } else {
-      dom.modelSelect.value = CUSTOM_MODEL_VALUE;
-      dom.customModel.value = normalized;
-    }
-    toggleCustomModel();
-  }
-
-  function priceLabel(model) {
-    const promptPrice = Number(model?.pricing?.prompt);
-    if (!Number.isFinite(promptPrice) || promptPrice <= 0) return promptPrice === 0 ? " · 免费" : "";
-    const perMillion = promptPrice * 1_000_000;
-    return ` · $${perMillion < 0.01 ? perMillion.toFixed(3) : perMillion.toFixed(2)}/M`;
-  }
-
-  function populateModelOptions(models) {
-    const selected = selectedModelFromForm() || settings.model || DEFAULT_MODEL;
-    const unique = new Map();
-    models.forEach(model => {
-      if (model?.id && !unique.has(model.id)) unique.set(model.id, model);
-    });
-
-    dom.modelSelect.innerHTML = "";
-    Array.from(unique.values()).slice(0, 100).forEach(model => {
-      const option = document.createElement("option");
-      option.value = model.id;
-      option.textContent = `${model.name || model.id}${priceLabel(model)}`;
-      dom.modelSelect.appendChild(option);
-    });
-    const customOption = document.createElement("option");
-    customOption.value = CUSTOM_MODEL_VALUE;
-    customOption.textContent = "其他模型 ID";
-    dom.modelSelect.appendChild(customOption);
-    setModelControls(selected);
-  }
-
-  async function loadVisionModels() {
-    if (modelsLoaded) return;
-    setSettingsStatus("正在获取可用的多模态模型…");
-    try {
-      const headers = settings.apiKey ? { Authorization: `Bearer ${settings.apiKey}` } : {};
-      const response = await fetch(MODELS_ENDPOINT, { headers });
-      if (!response.ok) throw new Error(`模型列表请求失败（${response.status}）`);
-      const payload = await response.json();
-      visionModels = Array.isArray(payload.data)
-        ? payload.data.filter(model => model?.architecture?.input_modalities?.includes("image") && model?.architecture?.output_modalities?.includes("text"))
-        : [];
-      if (!visionModels.length) throw new Error("没有获取到可用的图片模型");
-      populateModelOptions(visionModels);
-      modelsLoaded = true;
-      setSettingsStatus(`已获取 ${visionModels.length} 个支持图片输入的模型。`, "success");
-    } catch (error) {
-      setModelControls(settings.model);
-      setSettingsStatus(`${error.message || "模型列表加载失败"}，仍可手动填写模型 ID。`, "error");
-    }
   }
 
   function openSettings(message = "") {
     dom.apiKey.value = settings.apiKey;
     dom.apiKey.type = "password";
-    setModelControls(settings.model);
+    dom.modelInput.value = settings.model;
     setSettingsStatus(message);
     dom.settingsModal.hidden = false;
     refreshIcons();
-    loadVisionModels();
-    requestAnimationFrame(() => (settings.apiKey ? dom.modelSelect : dom.apiKey).focus());
+    requestAnimationFrame(() => (settings.apiKey ? dom.modelInput : dom.apiKey).focus());
   }
 
   function closeSettings() {
@@ -201,43 +109,53 @@
 
   function validateSettingsForm() {
     const apiKey = dom.apiKey.value.trim();
-    const model = selectedModelFromForm();
+    const model = normalizeModel(dom.modelInput.value);
     dom.apiKey.setCustomValidity("");
-    dom.modelSelect.setCustomValidity("");
-    dom.customModel.setCustomValidity("");
+    dom.modelInput.setCustomValidity("");
     if (!apiKey) {
       dom.apiKey.setCustomValidity("请输入 OpenRouter API Key");
       dom.apiKey.reportValidity();
       return null;
     }
     if (!model) {
-      const input = dom.modelSelect.value === CUSTOM_MODEL_VALUE ? dom.customModel : dom.modelSelect;
-      input.setCustomValidity("请选择或输入模型 ID");
-      input.reportValidity();
+      dom.modelInput.setCustomValidity("请输入模型 ID");
+      dom.modelInput.reportValidity();
       return null;
     }
-    const selectedOption = dom.modelSelect.selectedOptions[0];
-    const modelName = dom.modelSelect.value === CUSTOM_MODEL_VALUE
-      ? model.split("/").pop()
-      : (selectedOption?.textContent || model).replace(/ · \$.*$/, "").replace(/ · 免费$/, "");
-    return { apiKey, model, modelName };
+    return { apiKey, model };
+  }
+
+  function openRouterHeaders(apiKey) {
+    return {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      "HTTP-Referer": `${location.origin}${location.pathname}`,
+      "X-OpenRouter-Title": "See You On Land - Visual Solver"
+    };
   }
 
   async function testConnection() {
     const values = validateSettingsForm();
     if (!values) return;
     dom.testConnection.disabled = true;
-    setSettingsStatus("正在验证 API Key…");
+    setSettingsStatus("正在验证 API Key 和模型…");
     try {
-      const response = await fetch("https://openrouter.ai/api/v1/key", {
-        headers: { Authorization: `Bearer ${values.apiKey}` }
+      const response = await fetch(CHAT_ENDPOINT, {
+        method: "POST",
+        headers: openRouterHeaders(values.apiKey),
+        body: JSON.stringify({
+          model: values.model,
+          messages: [{ role: "user", content: "Reply with OK." }],
+          max_tokens: 4,
+          stream: false
+        })
       });
-      const payload = await response.json().catch(() => ({}));
-      if (!response.ok) throw new Error(payload?.error?.message || `验证失败（${response.status}）`);
-      const remaining = Number(payload?.data?.limit_remaining);
-      setSettingsStatus(Number.isFinite(remaining) ? `连接成功，可用额度 $${remaining.toFixed(2)}。` : "连接成功，API Key 可用。", "success");
+      if (!response.ok) await responseError(response);
+      const payload = await response.json();
+      if (!payload?.choices?.[0]?.message) throw new Error("模型没有返回有效响应");
+      setSettingsStatus("连接成功，API Key 和模型均可用。", "success");
     } catch (error) {
-      setSettingsStatus(error.message || "连接失败，请检查 API Key。", "error");
+      setSettingsStatus(friendlyError(error), "error");
     } finally {
       dom.testConnection.disabled = false;
     }
@@ -558,12 +476,7 @@
       const response = await fetch(CHAT_ENDPOINT, {
         method: "POST",
         signal: requestController.signal,
-        headers: {
-          Authorization: `Bearer ${settings.apiKey}`,
-          "Content-Type": "application/json",
-          "HTTP-Referer": `${location.origin}${location.pathname}`,
-          "X-OpenRouter-Title": "上岸学习 · 拍题搜题"
-        },
+        headers: openRouterHeaders(settings.apiKey),
         body: JSON.stringify({
           model: settings.model,
           messages: [{ role: "system", content: SYSTEM_PROMPT }, ...apiMessages(history)],
@@ -645,7 +558,6 @@
   });
 
   dom.settingsButton.addEventListener("click", () => openSettings());
-  dom.modelButton.addEventListener("click", () => openSettings());
   document.querySelectorAll("[data-close-solver-settings]").forEach(element => element.addEventListener("click", closeSettings));
   dom.apiKeyToggle.addEventListener("click", () => {
     const show = dom.apiKey.type === "password";
@@ -655,11 +567,7 @@
     dom.apiKeyToggle.innerHTML = `<i data-lucide="${show ? "eye-off" : "eye"}" aria-hidden="true"></i>`;
     refreshIcons();
   });
-  dom.modelSelect.addEventListener("change", () => {
-    dom.modelSelect.setCustomValidity("");
-    toggleCustomModel(true);
-  });
-  dom.customModel.addEventListener("input", () => dom.customModel.setCustomValidity(""));
+  dom.modelInput.addEventListener("input", () => dom.modelInput.setCustomValidity(""));
   dom.apiKey.addEventListener("input", () => dom.apiKey.setCustomValidity(""));
   dom.testConnection.addEventListener("click", testConnection);
   dom.settingsForm.addEventListener("submit", event => {
@@ -693,7 +601,6 @@
     }
   });
 
-  setModelControls(settings.model);
   renderConfigurationState();
   renderAttachments();
   renderConversation();


### PR DESCRIPTION
## Changes
- replace model dropdowns with one manually entered model ID field in settings
- remove the model picker from the chat composer
- fix browser chat requests by using an ASCII OpenRouter attribution header
- make connection testing call the configured model through the real chat-completions endpoint
- bump search asset versions to invalidate the GitHub Pages cache

## Verification
- node --check search.js
- python -m py_compile build_public_site.py
- python build_public_site.py
- verified the old Unicode header fails before transmission and the new header reaches OpenRouter
- browser-tested the simplified mobile settings and composer
- verified invalid credentials now return a specific 401 instead of a network error