### PR TITLE
Add AI-assisted wrong question review

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Assemble static site
         run: |
           mkdir -p _site
-          cp index.html clock.css clock.js search.css search.js backup.js learning-data.js current-affairs-data.js _site/
+          cp index.html clock.css clock.js search.css search.js wrong-questions.css wrong-questions.js wrong-question-taxonomy.json backup.js learning-data.js current-affairs-data.js _site/
           touch _site/.nojekyll
 
       - name: Configure Pages

--- a/build_public_site.py
+++ b/build_public_site.py
@@ -20,6 +20,9 @@ def main():
         "/clock.js": ("text/javascript; charset=utf-8", ROOT / "clock.js"),
         "/search.css": ("text/css; charset=utf-8", ROOT / "search.css"),
         "/search.js": ("text/javascript; charset=utf-8", ROOT / "search.js"),
+        "/wrong-questions.css": ("text/css; charset=utf-8", ROOT / "wrong-questions.css"),
+        "/wrong-questions.js": ("text/javascript; charset=utf-8", ROOT / "wrong-questions.js"),
+        "/wrong-question-taxonomy.json": ("application/json; charset=utf-8", ROOT / "wrong-question-taxonomy.json"),
     }
     route_source = ",\n".join(
         f"  {json.dumps(route)}: {{ type: {json.dumps(content_type)}, body: {javascript_string(path)} }}"

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <title>暑假时政学习清单</title>
   <link rel="stylesheet" href="clock.css?v=20260815-2">
   <link rel="stylesheet" href="search.css?v=20260821-4">
+  <link rel="stylesheet" href="wrong-questions.css?v=20260821-1">
   <style>
     :root {
       --bg: #ffffff;
@@ -1245,10 +1246,16 @@
             <i data-lucide="chevron-down" aria-hidden="true"></i>
           </button>
         </div>
-        <button type="button" class="icon-button solver-settings-button" id="open-solver-settings" title="搜题设置" aria-label="打开搜题设置">
-          <i data-lucide="settings-2" aria-hidden="true"></i>
-          <span class="solver-settings-dot" id="solver-settings-dot" aria-hidden="true"></span>
-        </button>
+        <div class="solver-header-actions">
+          <button type="button" class="icon-button solver-wrong-book-button" id="open-wrong-book" title="错题本" aria-label="打开错题本">
+            <i data-lucide="book-open-check" aria-hidden="true"></i>
+            <span class="solver-wrong-book-badge" id="wrong-book-due-badge" aria-label="0道待复习" hidden>0</span>
+          </button>
+          <button type="button" class="icon-button solver-settings-button" id="open-solver-settings" title="搜题设置" aria-label="打开搜题设置">
+            <i data-lucide="settings-2" aria-hidden="true"></i>
+            <span class="solver-settings-dot" id="solver-settings-dot" aria-hidden="true"></span>
+          </button>
+        </div>
       </header>
 
       <section class="solver-workspace" id="solver-workspace">
@@ -1281,6 +1288,61 @@
         <input type="file" id="solver-upload-input" accept="image/png,image/jpeg,image/webp,image/gif" multiple hidden>
       </form>
     </main>
+
+    <section class="wrong-book" id="wrong-book" aria-labelledby="wrong-book-title" hidden>
+      <header class="wrong-book-header">
+        <button type="button" class="icon-button" id="close-wrong-book" title="返回搜题" aria-label="返回搜题">
+          <i data-lucide="arrow-left" aria-hidden="true"></i>
+        </button>
+        <div>
+          <p class="eyebrow" id="wrong-book-kicker">REVIEW</p>
+          <h1 id="wrong-book-title">错题本</h1>
+        </div>
+        <div class="wrong-book-header-actions" id="wrong-book-transfer-actions">
+          <button type="button" class="icon-button" id="import-wrong-questions" title="导入错题" aria-label="导入错题"><i data-lucide="upload" aria-hidden="true"></i></button>
+          <button type="button" class="icon-button" id="export-wrong-questions" title="导出错题" aria-label="导出错题"><i data-lucide="download" aria-hidden="true"></i></button>
+        </div>
+      </header>
+
+      <div class="wrong-book-list-view" id="wrong-book-list-view">
+        <section class="wrong-book-overview" aria-label="错题复习概况">
+          <div><strong id="wrong-book-due-count">0</strong><span>今日待复习</span></div>
+          <div><strong id="wrong-book-total-count">0</strong><span>错题总数</span></div>
+          <button type="button" id="start-wrong-review"><i data-lucide="play" aria-hidden="true"></i><span>开始复习</span></button>
+        </section>
+
+        <div class="wrong-book-toolbar">
+          <div class="wrong-book-tabs" role="tablist" aria-label="错题范围">
+            <button type="button" class="active" data-wrong-scope="due" role="tab" aria-selected="true">待复习</button>
+            <button type="button" data-wrong-scope="all" role="tab" aria-selected="false">全部</button>
+          </div>
+          <label class="wrong-book-subject-filter">
+            <span class="visually-hidden">筛选科目</span>
+            <select id="wrong-book-subject"><option value="">全部科目</option></select>
+            <i data-lucide="chevron-down" aria-hidden="true"></i>
+          </label>
+        </div>
+
+        <p class="wrong-book-status" id="wrong-book-status" role="status" aria-live="polite"></p>
+        <div class="wrong-book-records" id="wrong-book-records"></div>
+      </div>
+
+      <div class="wrong-book-review-view" id="wrong-book-review-view" hidden>
+        <div class="wrong-review-progress">
+          <span id="wrong-review-position">1 / 1</span>
+          <span id="wrong-review-subject">科目</span>
+        </div>
+        <div class="wrong-review-track"><span id="wrong-review-progress-bar"></span></div>
+        <article class="wrong-review-content" id="wrong-review-content"></article>
+        <footer class="wrong-review-actions" aria-label="本题掌握程度">
+          <button type="button" data-review-grade="forgot"><i data-lucide="rotate-ccw" aria-hidden="true"></i><span>忘记</span><small>明天</small></button>
+          <button type="button" data-review-grade="fuzzy"><i data-lucide="circle-help" aria-hidden="true"></i><span>模糊</span><small>稍后再看</small></button>
+          <button type="button" data-review-grade="mastered"><i data-lucide="check" aria-hidden="true"></i><span>掌握</span><small>延长间隔</small></button>
+        </footer>
+      </div>
+    </section>
+
+    <input type="file" id="wrong-question-import-input" accept="application/json,.json" hidden>
 
     <nav class="tab-bar" aria-label="主导航">
       <button type="button" class="tab-item active" data-tab="dashboard" aria-selected="true">
@@ -1861,6 +1923,7 @@
   <script src="backup.js?v=20260815-1"></script>
   <script src="https://cdn.jsdelivr.net/npm/marked@18.0.10/lib/marked.umd.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.14/dist/purify.min.js"></script>
-  <script src="search.js?v=20260821-3"></script>
+  <script src="wrong-questions.js?v=20260821-1"></script>
+  <script src="search.js?v=20260821-4"></script>
 </body>
 </html>

--- a/search.js
+++ b/search.js
@@ -64,6 +64,7 @@
   let persistenceTimer = 0;
   let reasoningTimer = 0;
   let databasePromise = null;
+  const wrongAnalysisControllers = new Map();
 
   function loadSettings() {
     try {
@@ -255,6 +256,14 @@
       reasoningSeconds: Number.isFinite(Number(message?.reasoningSeconds)) ? Number(message.reasoningSeconds) : 0,
       status: message?.status === "streaming" ? "stopped" : (message?.status || "done"),
       modelName: typeof message?.modelName === "string" ? message.modelName : "",
+      wrongQuestionStatus: message?.role === "assistant"
+        ? (message?.wrongQuestionStatus === "analyzing" ? "error" : (message?.wrongQuestionStatus || "idle"))
+        : "idle",
+      wrongQuestionAnalysis: message?.role === "assistant" && message?.wrongQuestionAnalysis && typeof message.wrongQuestionAnalysis === "object"
+        ? message.wrongQuestionAnalysis
+        : null,
+      wrongQuestionId: message?.role === "assistant" && typeof message?.wrongQuestionId === "string" ? message.wrongQuestionId : "",
+      wrongQuestionError: message?.role === "assistant" && typeof message?.wrongQuestionError === "string" ? message.wrongQuestionError : "",
       createdAt: Number(message?.createdAt) || Date.now()
     })).filter(message => message.role === "user" || message.text || message.reasoning) : [];
     return {
@@ -664,6 +673,147 @@
     return reasoning;
   }
 
+  function wrongQuestionSource(session, assistantMessage) {
+    if (!session || !assistantMessage) return null;
+    const index = session.messages.findIndex(message => message.id === assistantMessage.id);
+    for (let position = index - 1; position >= 0; position -= 1) {
+      if (session.messages[position].role === "user") return session.messages[position];
+    }
+    return null;
+  }
+
+  function wrongQuestionKindLabel(kind) {
+    return ({
+      term: "词义辨析",
+      rule: "规则",
+      formula: "公式",
+      method: "方法",
+      mistake: "易错点",
+      material_point: "材料要点",
+      argument: "论点论据",
+      fact: "知识事实",
+      other: "知识点"
+    })[kind] || "知识点";
+  }
+
+  function createWrongCandidate(id, titleText, description, checked = false, kind = "") {
+    const label = document.createElement("label");
+    label.className = "solver-wrong-candidate";
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    input.name = "wrong-items";
+    input.value = id;
+    input.checked = checked;
+    const check = document.createElement("span");
+    check.className = "solver-wrong-check";
+    check.innerHTML = '<i data-lucide="check" aria-hidden="true"></i>';
+    const copy = document.createElement("span");
+    copy.className = "solver-wrong-candidate-copy";
+    const title = document.createElement("strong");
+    title.textContent = kind ? `${titleText} · ${wrongQuestionKindLabel(kind)}` : titleText;
+    const summary = document.createElement("span");
+    summary.textContent = description;
+    copy.appendChild(title);
+    if (description) copy.appendChild(summary);
+    label.append(input, check, copy);
+    return label;
+  }
+
+  function createWrongCaptureElement(message) {
+    const capture = document.createElement("section");
+    capture.className = "solver-wrong-capture";
+    capture.dataset.wrongCapture = message.id;
+    const status = message.wrongQuestionStatus || "idle";
+
+    if (status === "analyzing") {
+      const loading = document.createElement("div");
+      loading.className = "solver-wrong-loading";
+      loading.innerHTML = '<i data-lucide="loader-circle" aria-hidden="true"></i><span>正在识别题型与可复习知识…</span>';
+      capture.appendChild(loading);
+      return capture;
+    }
+
+    if (status === "error") {
+      const error = document.createElement("div");
+      error.className = "solver-wrong-error";
+      const copy = document.createElement("span");
+      copy.textContent = message.wrongQuestionError || "未能自动整理错题。";
+      const retry = document.createElement("button");
+      retry.type = "button";
+      retry.dataset.wrongAction = "retry";
+      retry.dataset.messageId = message.id;
+      retry.textContent = "重新识别";
+      error.append(copy, retry);
+      capture.appendChild(error);
+      return capture;
+    }
+
+    if (status !== "ready" || !message.wrongQuestionAnalysis) {
+      capture.hidden = true;
+      return capture;
+    }
+
+    const analysis = message.wrongQuestionAnalysis;
+    const header = document.createElement("div");
+    header.className = "solver-wrong-capture-header";
+    const title = document.createElement("h3");
+    title.className = "solver-wrong-capture-title";
+    title.textContent = "记录这次不会的内容";
+    const type = document.createElement("span");
+    type.className = "solver-wrong-type";
+    type.textContent = [analysis.subjectLabel, analysis.typeLabel].filter(Boolean).join(" · ");
+    header.append(title, type);
+
+    const intro = document.createElement("p");
+    intro.className = "solver-wrong-capture-intro";
+    intro.textContent = "选择需要以后单独复习的内容，也可以补充自己的易错点。";
+    const candidates = document.createElement("div");
+    candidates.className = "solver-wrong-candidates";
+    candidates.appendChild(createWrongCandidate("__whole__", "整道题与解题方法", "保留原题、答案和完整解析"));
+    (analysis.candidates || []).forEach(item => {
+      candidates.appendChild(createWrongCandidate(
+        item.id,
+        item.title,
+        [item.summary, ...(item.details || [])].filter(Boolean).join("；"),
+        false,
+        item.kind
+      ));
+    });
+
+    const custom = document.createElement("label");
+    custom.className = "solver-wrong-custom";
+    const customLabel = document.createElement("span");
+    customLabel.textContent = "自定义补充";
+    const customInput = document.createElement("input");
+    customInput.type = "text";
+    customInput.maxLength = 300;
+    customInput.dataset.wrongCustom = "";
+    customInput.placeholder = "例如：容易忽略转折后的核心句";
+    custom.append(customLabel, customInput);
+
+    const captureStatus = document.createElement("p");
+    captureStatus.className = "solver-wrong-capture-status";
+    captureStatus.setAttribute("role", "status");
+    const actions = document.createElement("div");
+    actions.className = "solver-wrong-capture-actions";
+    const skip = document.createElement("button");
+    skip.type = "button";
+    skip.className = "solver-wrong-skip";
+    skip.dataset.wrongAction = "dismiss";
+    skip.dataset.messageId = message.id;
+    skip.textContent = "稍后记录";
+    const save = document.createElement("button");
+    save.type = "button";
+    save.className = "solver-wrong-save";
+    save.dataset.wrongAction = "save";
+    save.dataset.messageId = message.id;
+    save.disabled = true;
+    save.textContent = "保存到错题本";
+    actions.append(skip, save);
+    capture.append(header, intro, candidates, custom, captureStatus, actions);
+    return capture;
+  }
+
   function createMessageElement(message) {
     const article = document.createElement("article");
     article.className = `solver-message ${message.role}${message.status === "error" ? " error" : ""}`;
@@ -703,6 +853,8 @@
     article.append(heading, reasoning, copy);
 
     if (message.status !== "streaming" && message.text) {
+      const capture = createWrongCaptureElement(message);
+      article.appendChild(capture);
       const footer = document.createElement("div");
       footer.className = "solver-message-footer";
       const copyButton = document.createElement("button");
@@ -713,6 +865,18 @@
       copyButton.setAttribute("aria-label", "复制回答");
       copyButton.innerHTML = '<i data-lucide="copy" aria-hidden="true"></i>';
       footer.appendChild(copyButton);
+      const wrongButton = document.createElement("button");
+      wrongButton.type = "button";
+      wrongButton.className = message.wrongQuestionStatus === "saved" ? "solver-wrong-saved-link" : "solver-wrong-trigger";
+      wrongButton.dataset.messageId = message.id;
+      if (message.wrongQuestionStatus === "saved" && message.wrongQuestionId) {
+        wrongButton.dataset.wrongAction = "open-record";
+        wrongButton.innerHTML = '<i data-lucide="book-check" aria-hidden="true"></i><span>已加入错题本</span>';
+      } else {
+        wrongButton.dataset.wrongAction = "open";
+        wrongButton.innerHTML = '<i data-lucide="bookmark-plus" aria-hidden="true"></i><span>记录错题</span>';
+      }
+      footer.appendChild(wrongButton);
       if (message.status === "stopped") {
         const stopped = document.createElement("span");
         stopped.textContent = "已停止生成";
@@ -751,6 +915,63 @@
     else copy.textContent = "正在分析题目…";
     copy.classList.toggle("solver-stream-cursor", message.status === "streaming");
     scrollToLatest(true);
+  }
+
+  function rerenderAssistantMessage(message, smooth = false) {
+    const article = Array.from(dom.messages.querySelectorAll("[data-message-id]")).find(item => item.dataset.messageId === message.id);
+    if (!article) {
+      renderConversation();
+      return;
+    }
+    article.replaceWith(createMessageElement(message));
+    refreshIcons(dom.messages);
+    if (smooth) scrollToLatest(true);
+  }
+
+  function updateWrongSaveButton(capture) {
+    if (!capture) return;
+    const selected = capture.querySelector('input[name="wrong-items"]:checked');
+    const custom = capture.querySelector("[data-wrong-custom]")?.value.trim();
+    const save = capture.querySelector('[data-wrong-action="save"]');
+    if (save) save.disabled = !selected && !custom;
+  }
+
+  async function analyzeWrongQuestion(session, userMessage, assistantMessage) {
+    if (!window.wrongQuestionBook || !session || !userMessage || !assistantMessage?.text) return;
+    wrongAnalysisControllers.get(assistantMessage.id)?.abort();
+    const controller = new AbortController();
+    wrongAnalysisControllers.set(assistantMessage.id, controller);
+    assistantMessage.wrongQuestionStatus = "analyzing";
+    assistantMessage.wrongQuestionError = "";
+    scheduleSessionSave(session);
+    if (activeSessionId === session.id) rerenderAssistantMessage(assistantMessage, true);
+    try {
+      await window.wrongQuestionBook.ready;
+      const analysis = await window.wrongQuestionBook.analyzeQuestion({
+        apiKey: settings.apiKey,
+        model: settings.model,
+        headers: openRouterHeaders,
+        userMessage,
+        assistantText: assistantMessage.text,
+        signal: controller.signal
+      });
+      if (wrongAnalysisControllers.get(assistantMessage.id) !== controller) return;
+      assistantMessage.wrongQuestionAnalysis = analysis;
+      assistantMessage.wrongQuestionStatus = "ready";
+      assistantMessage.wrongQuestionError = "";
+    } catch (error) {
+      if (error?.name === "AbortError") return;
+      assistantMessage.wrongQuestionStatus = "error";
+      assistantMessage.wrongQuestionError = error?.status === 402
+        ? "错题整理需要额外调用一次模型，当前额度不足。"
+        : "自动整理失败，可以重新识别。";
+    } finally {
+      if (wrongAnalysisControllers.get(assistantMessage.id) === controller) {
+        wrongAnalysisControllers.delete(assistantMessage.id);
+        scheduleSessionSave(session, true);
+        if (activeSessionId === session.id) rerenderAssistantMessage(assistantMessage, true);
+      }
+    }
   }
 
   function scrollToLatest(smooth = false) {
@@ -937,6 +1158,7 @@
     const session = activeSession();
     if (!session) return;
     const sessionMessages = session.messages;
+    let shouldAnalyzeWrongQuestion = false;
     const userMessage = {
       id: `user-${Date.now()}`,
       role: "user",
@@ -963,6 +1185,10 @@
       reasoningEndedAt: 0,
       status: "streaming",
       modelName: currentModelLabel(),
+      wrongQuestionStatus: "idle",
+      wrongQuestionAnalysis: null,
+      wrongQuestionId: "",
+      wrongQuestionError: "",
       createdAt: Date.now()
     };
     sessionMessages.push(assistant);
@@ -1011,6 +1237,7 @@
       });
       if (!assistant.text.trim()) throw new Error("模型没有返回正文内容，请更换模型后重试。");
       assistant.status = "done";
+      shouldAnalyzeWrongQuestion = true;
     } catch (error) {
       if (error?.name === "AbortError") {
         if (assistant.text.trim() || assistant.reasoning.trim()) {
@@ -1038,6 +1265,9 @@
         conversation = sessionMessages;
         renderConversation();
         renderSessionList();
+      }
+      if (shouldAnalyzeWrongQuestion) {
+        window.setTimeout(() => analyzeWrongQuestion(session, userMessage, assistant), 0);
       }
     }
   }
@@ -1089,16 +1319,101 @@
   });
 
   dom.messages.addEventListener("click", async event => {
-    const button = event.target.closest("button[data-copy-message]");
-    if (!button) return;
-    const message = conversation.find(item => item.id === button.dataset.copyMessage);
-    if (!message?.text) return;
-    try {
-      await navigator.clipboard.writeText(message.text);
-      setStatus("回答已复制。", false);
-    } catch {
-      setStatus("复制失败，请长按回答文字复制。", true);
+    const copyButton = event.target.closest("button[data-copy-message]");
+    if (copyButton) {
+      const message = conversation.find(item => item.id === copyButton.dataset.copyMessage);
+      if (!message?.text) return;
+      try {
+        await navigator.clipboard.writeText(message.text);
+        setStatus("回答已复制。", false);
+      } catch {
+        setStatus("复制失败，请长按回答文字复制。", true);
+      }
+      return;
     }
+
+    const button = event.target.closest("button[data-wrong-action]");
+    if (!button) return;
+    const session = activeSession();
+    const message = session?.messages.find(item => item.id === button.dataset.messageId);
+    if (!session || !message) return;
+    const userMessage = wrongQuestionSource(session, message);
+    const action = button.dataset.wrongAction;
+
+    if (action === "open-record") {
+      window.wrongQuestionBook?.open(message.wrongQuestionId);
+      return;
+    }
+    if (action === "open") {
+      if (message.wrongQuestionAnalysis) {
+        message.wrongQuestionStatus = "ready";
+        scheduleSessionSave(session);
+        rerenderAssistantMessage(message, true);
+      } else {
+        analyzeWrongQuestion(session, userMessage, message);
+      }
+      return;
+    }
+    if (action === "retry") {
+      analyzeWrongQuestion(session, userMessage, message);
+      return;
+    }
+    if (action === "dismiss") {
+      message.wrongQuestionStatus = "dismissed";
+      scheduleSessionSave(session);
+      rerenderAssistantMessage(message);
+      return;
+    }
+    if (action !== "save") return;
+
+    const article = event.target.closest(".solver-message");
+    const capture = article?.querySelector("[data-wrong-capture]");
+    const captureStatus = capture?.querySelector(".solver-wrong-capture-status");
+    const selectedIds = Array.from(capture?.querySelectorAll('input[name="wrong-items"]:checked') || []).map(input => input.value);
+    const customText = capture?.querySelector("[data-wrong-custom]")?.value.trim() || "";
+    if (!selectedIds.length && !customText) {
+      if (captureStatus) {
+        captureStatus.textContent = "请至少选择或填写一项需要复习的内容。";
+        captureStatus.classList.add("error");
+      }
+      return;
+    }
+    button.disabled = true;
+    button.textContent = "保存中…";
+    if (captureStatus) {
+      captureStatus.textContent = "";
+      captureStatus.classList.remove("error");
+    }
+    try {
+      const record = await window.wrongQuestionBook.saveFromConversation({
+        sessionId: session.id,
+        userMessage,
+        assistantMessage: message,
+        selectedIds,
+        customText
+      });
+      message.wrongQuestionId = record.id;
+      message.wrongQuestionStatus = "saved";
+      scheduleSessionSave(session, true);
+      rerenderAssistantMessage(message);
+      setStatus("已保存到错题本，今天即可开始复习。", false);
+    } catch (error) {
+      button.disabled = false;
+      button.textContent = "保存到错题本";
+      if (captureStatus) {
+        captureStatus.textContent = error?.message || "错题保存失败，请重试。";
+        captureStatus.classList.add("error");
+      }
+    }
+  });
+
+  dom.messages.addEventListener("input", event => {
+    const capture = event.target.closest("[data-wrong-capture]");
+    if (capture) updateWrongSaveButton(capture);
+  });
+  dom.messages.addEventListener("change", event => {
+    const capture = event.target.closest("[data-wrong-capture]");
+    if (capture) updateWrongSaveButton(capture);
   });
 
   dom.settingsButton.addEventListener("click", () => openSettings());
@@ -1177,7 +1492,23 @@
       scrollToLatest(false);
     }
   });
+  window.addEventListener("wrong-question:deleted", event => {
+    const recordId = event.detail?.record?.id;
+    if (!recordId) return;
+    sessions.forEach(session => {
+      let changed = false;
+      session.messages.forEach(message => {
+        if (message.wrongQuestionId !== recordId) return;
+        message.wrongQuestionId = "";
+        message.wrongQuestionStatus = message.wrongQuestionAnalysis ? "ready" : "idle";
+        changed = true;
+      });
+      if (changed) scheduleSessionSave(session, true);
+    });
+    renderConversation();
+  });
   window.addEventListener("pagehide", () => {
+    wrongAnalysisControllers.forEach(controller => controller.abort());
     const session = activeSession();
     if (session) scheduleSessionSave(session, true);
   });

--- a/wrong-questions.css
+++ b/wrong-questions.css
@@ -1,0 +1,626 @@
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+.solver-header-actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.solver-wrong-book-button {
+  position: relative;
+  width: 44px;
+  height: 44px;
+  border: 1px solid var(--line);
+  background: var(--bg);
+  color: var(--ink);
+}
+
+.solver-wrong-book-badge {
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  min-width: 19px;
+  height: 19px;
+  display: grid;
+  place-items: center;
+  padding: 0 5px;
+  border: 2px solid var(--bg);
+  border-radius: 10px;
+  background: var(--red);
+  color: #fff;
+  font-size: 10px;
+  line-height: 1;
+}
+
+.solver-wrong-book-badge[hidden] { display: none; }
+
+.solver-wrong-trigger,
+.solver-wrong-saved-link {
+  min-height: 32px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.solver-wrong-trigger:hover,
+.solver-wrong-saved-link:hover { color: var(--red); }
+
+.solver-wrong-trigger .lucide,
+.solver-wrong-saved-link .lucide { width: 16px; height: 16px; }
+
+.solver-wrong-capture {
+  width: 100%;
+  margin-top: 18px;
+  padding: 16px 0 2px;
+  border-top: 1px solid var(--line);
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Microsoft YaHei", sans-serif;
+}
+
+.solver-wrong-capture[hidden] { display: none; }
+
+.solver-wrong-loading {
+  min-height: 42px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.solver-wrong-loading .lucide {
+  width: 17px;
+  height: 17px;
+  color: var(--red);
+  animation: wrong-spin 900ms linear infinite;
+}
+
+.solver-wrong-capture-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 5px;
+}
+
+.solver-wrong-capture-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.solver-wrong-type {
+  flex: 0 0 auto;
+  max-width: 54%;
+  padding: 4px 7px;
+  overflow: hidden;
+  border: 1px solid #e1c8c8;
+  border-radius: 4px;
+  color: var(--red);
+  font-size: 11px;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.solver-wrong-capture-intro {
+  margin: 0 0 13px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.solver-wrong-candidates {
+  display: grid;
+  gap: 0;
+  border-top: 1px solid var(--line);
+}
+
+.solver-wrong-candidate {
+  position: relative;
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  gap: 9px;
+  padding: 12px 2px;
+  border-bottom: 1px solid var(--line);
+  cursor: pointer;
+}
+
+.solver-wrong-candidate input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.solver-wrong-check {
+  width: 20px;
+  height: 20px;
+  display: grid;
+  place-items: center;
+  margin-top: 2px;
+  border: 1px solid #aab2b0;
+  border-radius: 3px;
+  background: var(--bg);
+  color: transparent;
+}
+
+.solver-wrong-check .lucide { width: 14px; height: 14px; }
+.solver-wrong-candidate input:checked + .solver-wrong-check { border-color: var(--red); background: var(--red); color: #fff; }
+.solver-wrong-candidate input:focus-visible + .solver-wrong-check { outline: 2px solid var(--ink); outline-offset: 2px; }
+
+.solver-wrong-candidate-copy { min-width: 0; }
+.solver-wrong-candidate-copy strong { display: block; font-size: 15px; font-weight: 500; line-height: 1.45; }
+.solver-wrong-candidate-copy span { display: block; margin-top: 3px; color: var(--muted); font-size: 13px; line-height: 1.55; overflow-wrap: anywhere; }
+
+.solver-wrong-custom {
+  display: grid;
+  gap: 6px;
+  margin-top: 13px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.solver-wrong-custom input {
+  width: 100%;
+  min-height: 44px;
+  padding: 9px 11px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--ink);
+  font: inherit;
+  font-size: 14px;
+}
+
+.solver-wrong-custom input:focus { border-color: #aab3b1; outline: 0; }
+
+.solver-wrong-capture-status {
+  min-height: 20px;
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.solver-wrong-capture-status.error { color: var(--red); }
+
+.solver-wrong-capture-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.solver-wrong-capture-actions button {
+  min-height: 42px;
+  padding: 0 14px;
+  border-radius: 4px;
+  font: inherit;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.solver-wrong-skip { border: 0; background: transparent; color: var(--muted); }
+.solver-wrong-save { border: 1px solid var(--red); background: var(--red); color: #fff; }
+.solver-wrong-save:disabled { border-color: #c9cecd; background: #c9cecd; cursor: default; }
+
+.solver-wrong-error {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 44px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.solver-wrong-error button {
+  margin-left: auto;
+  min-height: 36px;
+  padding: 0 11px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--ink);
+  font: inherit;
+  cursor: pointer;
+}
+
+.wrong-book[hidden] { display: none; }
+
+.wrong-book {
+  position: absolute;
+  inset: 0;
+  z-index: 350;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--bg);
+}
+
+.wrong-book-header {
+  flex: 0 0 auto;
+  min-height: 78px;
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: calc(12px + env(safe-area-inset-top)) 16px 10px;
+  border-bottom: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.97);
+}
+
+.wrong-book-header > .icon-button,
+.wrong-book-header-actions .icon-button {
+  width: 44px;
+  height: 44px;
+  border: 0;
+  background: transparent;
+}
+
+.wrong-book-header h1 {
+  margin: 1px 0 0;
+  font-size: 25px;
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+.wrong-book-header .eyebrow { margin: 0; font-size: 10px; }
+.wrong-book-header-actions { display: flex; align-items: center; }
+.wrong-book-header-actions[hidden] { display: none; }
+
+.wrong-book-list-view,
+.wrong-book-review-view {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+
+.wrong-book-list-view::-webkit-scrollbar,
+.wrong-book-review-view::-webkit-scrollbar { display: none; }
+.wrong-book-list-view[hidden],
+.wrong-book-review-view[hidden] { display: none; }
+
+.wrong-book-overview {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+  padding: 24px 20px 20px;
+  border-bottom: 1px solid var(--line);
+}
+
+.wrong-book-overview > div {
+  display: grid;
+  gap: 3px;
+  padding: 0 12px 18px 0;
+}
+
+.wrong-book-overview strong {
+  font-family: "Songti SC", "STSong", "SimSun", Georgia, serif;
+  font-size: 34px;
+  font-weight: 400;
+  line-height: 1;
+}
+
+.wrong-book-overview span { color: var(--muted); font-size: 13px; }
+
+#start-wrong-review {
+  grid-column: 1 / -1;
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 1px solid var(--red);
+  border-radius: 5px;
+  background: var(--red);
+  color: #fff;
+  font: inherit;
+  font-size: 15px;
+  cursor: pointer;
+}
+
+#start-wrong-review:disabled { border-color: #c9cecd; background: #c9cecd; cursor: default; }
+#start-wrong-review .lucide { width: 17px; height: 17px; }
+
+.wrong-book-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.97);
+}
+
+.wrong-book-tabs {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  width: 154px;
+  padding: 3px;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  background: var(--surface);
+}
+
+.wrong-book-tabs button {
+  min-height: 34px;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.wrong-book-tabs button.active { background: var(--bg); color: var(--ink); box-shadow: 0 1px 4px rgba(20, 28, 28, 0.09); }
+
+.wrong-book-subject-filter {
+  position: relative;
+  min-width: 112px;
+}
+
+.wrong-book-subject-filter select {
+  width: 100%;
+  min-height: 40px;
+  padding: 7px 30px 7px 10px;
+  appearance: none;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--ink);
+  font: inherit;
+  font-size: 13px;
+}
+
+.wrong-book-subject-filter .lucide {
+  position: absolute;
+  top: 50%;
+  right: 9px;
+  width: 15px;
+  height: 15px;
+  color: var(--muted);
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+
+.wrong-book-status {
+  min-height: 20px;
+  margin: 0;
+  padding: 9px 20px 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.wrong-book-status:empty { min-height: 0; padding-top: 0; }
+.wrong-book-status.error { color: var(--red); }
+.wrong-book-records { padding: 0 20px calc(28px + env(safe-area-inset-bottom)); }
+
+.wrong-book-empty {
+  display: grid;
+  place-items: center;
+  min-height: 280px;
+  padding: 44px 24px;
+  color: var(--muted);
+  text-align: center;
+}
+
+.wrong-book-empty .lucide { width: 34px; height: 34px; margin-bottom: 13px; color: #aab2b0; }
+.wrong-book-empty h2 { margin: 0; color: var(--ink); font-size: 19px; font-weight: 500; }
+.wrong-book-empty p { max-width: 280px; margin: 7px 0 0; font-size: 13px; line-height: 1.6; }
+
+.wrong-record {
+  border-bottom: 1px solid var(--line);
+}
+
+.wrong-record summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  padding: 16px 0;
+  cursor: pointer;
+  list-style: none;
+}
+
+.wrong-record summary::-webkit-details-marker { display: none; }
+.wrong-record-main { min-width: 0; }
+.wrong-record-meta { display: flex; align-items: center; gap: 7px; margin-bottom: 6px; color: var(--red); font-size: 11px; }
+.wrong-record-meta span + span::before { content: "·"; margin-right: 7px; color: var(--muted); }
+.wrong-record h2 { margin: 0; overflow: hidden; font-size: 16px; font-weight: 500; line-height: 1.45; text-overflow: ellipsis; white-space: nowrap; }
+.wrong-record-knowledge { margin: 5px 0 0; overflow: hidden; color: var(--muted); font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
+.wrong-record-due { align-self: center; color: var(--muted); font-size: 11px; white-space: nowrap; }
+.wrong-record-due.today { color: var(--red); }
+
+.wrong-record-body {
+  padding: 0 0 16px;
+}
+
+.wrong-record-question {
+  margin: 0 0 12px;
+  color: #47504e;
+  font-family: "Songti SC", "STSong", "SimSun", Georgia, serif;
+  font-size: 15px;
+  line-height: 1.7;
+  white-space: pre-wrap;
+}
+
+.wrong-record-items { display: grid; gap: 8px; }
+.wrong-record-item { padding-left: 11px; border-left: 2px solid var(--red); }
+.wrong-record-item strong { display: block; font-size: 14px; font-weight: 500; }
+.wrong-record-item span { display: block; margin-top: 2px; color: var(--muted); font-size: 12px; line-height: 1.5; }
+
+.wrong-record-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 4px;
+  margin-top: 12px;
+}
+
+.wrong-record-actions button {
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.wrong-record-actions button[data-wrong-delete] { color: var(--red); }
+.wrong-record-actions .lucide { width: 17px; height: 17px; }
+
+.wrong-review-progress {
+  display: flex;
+  justify-content: space-between;
+  padding: 16px 20px 10px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.wrong-review-track { height: 3px; margin: 0 20px; overflow: hidden; background: var(--line); }
+.wrong-review-track span { display: block; width: 0; height: 100%; background: var(--red); transition: width 200ms ease; }
+
+.wrong-review-content {
+  padding: 22px 20px 128px;
+}
+
+.wrong-review-source-images {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.wrong-review-source-images img {
+  width: 100%;
+  max-height: 300px;
+  object-fit: contain;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  background: var(--surface);
+}
+
+.wrong-review-question {
+  margin: 0 0 22px;
+  font-family: "Songti SC", "STSong", "SimSun", Georgia, serif;
+  font-size: 18px;
+  line-height: 1.85;
+  white-space: pre-wrap;
+}
+
+.wrong-review-heading { margin: 24px 0 10px; font-size: 14px; font-weight: 500; }
+.wrong-review-knowledge { display: grid; gap: 10px; }
+.wrong-review-knowledge-item { padding: 12px 0 12px 13px; border-left: 3px solid var(--red); }
+.wrong-review-knowledge-item strong { display: block; font-size: 16px; font-weight: 500; line-height: 1.45; }
+.wrong-review-knowledge-item p { margin: 5px 0 0; color: var(--muted); font-size: 14px; line-height: 1.65; }
+
+.wrong-review-answer {
+  margin-top: 22px;
+  border-top: 1px solid var(--line);
+}
+
+.wrong-review-answer summary {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 13px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.wrong-review-answer summary::-webkit-details-marker { display: none; }
+.wrong-review-answer summary .lucide { width: 16px; height: 16px; }
+.wrong-review-answer-copy { padding-bottom: 8px; font-family: "Songti SC", "STSong", "SimSun", Georgia, serif; font-size: 15px; line-height: 1.8; }
+
+.wrong-review-actions {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  padding: 10px 12px calc(10px + env(safe-area-inset-bottom));
+  border-top: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.97);
+}
+
+.wrong-review-actions button {
+  min-width: 0;
+  min-height: 60px;
+  display: grid;
+  grid-template-columns: 20px auto;
+  grid-template-rows: auto auto;
+  justify-content: center;
+  column-gap: 6px;
+  padding: 8px 5px;
+  border: 0;
+  background: transparent;
+  color: var(--ink);
+  font: inherit;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.wrong-review-actions button + button { border-left: 1px solid var(--line); }
+.wrong-review-actions button:disabled { opacity: 0.42; cursor: default; }
+.wrong-review-actions .lucide { grid-row: 1 / 3; align-self: center; width: 18px; height: 18px; color: var(--red); }
+.wrong-review-actions small { color: var(--muted); font-size: 10px; white-space: nowrap; }
+
+@keyframes wrong-spin { to { transform: rotate(360deg); } }
+
+@media (max-width: 380px) {
+  .solver-header { gap: 10px; }
+  .solver-header-actions { gap: 3px; }
+  .solver-wrong-book-button,
+  .solver-settings-button { width: 40px; height: 40px; }
+  .solver-session-switch { max-width: calc(100vw - 116px); font-size: 24px; gap: 7px; }
+  .wrong-book-toolbar { align-items: stretch; flex-direction: column; }
+  .wrong-book-tabs,
+  .wrong-book-subject-filter { width: 100%; }
+  .solver-wrong-capture-header { display: grid; }
+  .solver-wrong-type { max-width: 100%; width: fit-content; }
+}
+
+@media (min-width: 600px) {
+  .wrong-book-header,
+  .wrong-book-overview,
+  .wrong-book-toolbar,
+  .wrong-book-status,
+  .wrong-book-records,
+  .wrong-review-progress,
+  .wrong-review-content { padding-left: max(28px, calc((100% - 720px) / 2)); padding-right: max(28px, calc((100% - 720px) / 2)); }
+  .wrong-review-track { margin-left: max(28px, calc((100% - 720px) / 2)); margin-right: max(28px, calc((100% - 720px) / 2)); }
+  .wrong-review-actions { padding-left: max(28px, calc((100% - 720px) / 2)); padding-right: max(28px, calc((100% - 720px) / 2)); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .solver-wrong-loading .lucide { animation-duration: 1800ms; }
+  .wrong-review-track span { transition: none; }
+}

--- a/wrong-questions.js
+++ b/wrong-questions.js
@@ -1,0 +1,885 @@
+(() => {
+  "use strict";
+
+  const DB_NAME = "summer-politics-wrong-questions";
+  const DB_VERSION = 1;
+  const STORE_NAME = "wrongQuestions";
+  const CHAT_ENDPOINT = "https://openrouter.ai/api/v1/chat/completions";
+  const TAXONOMY_URL = "wrong-question-taxonomy.json?v=20260821-1";
+  const DAY = 24 * 60 * 60 * 1000;
+  const MAX_IMPORT_BYTES = 30 * 1024 * 1024;
+  const FALLBACK_SUBJECTS = [
+    ["political_theory", "政治理论"],
+    ["general_knowledge", "常识判断/常识应用"],
+    ["verbal", "言语理解与表达"],
+    ["quantitative", "数量关系"],
+    ["judgment_reasoning", "判断推理"],
+    ["data_analysis", "资料分析"],
+    ["essay", "申论"],
+    ["administrative_enforcement", "行政执法专业"],
+    ["police_professional", "公安专业"]
+  ].map(([id, label]) => ({ id, label, types: [] }));
+
+  const dom = {
+    book: document.getElementById("wrong-book"),
+    open: document.getElementById("open-wrong-book"),
+    close: document.getElementById("close-wrong-book"),
+    badge: document.getElementById("wrong-book-due-badge"),
+    kicker: document.getElementById("wrong-book-kicker"),
+    title: document.getElementById("wrong-book-title"),
+    transferActions: document.getElementById("wrong-book-transfer-actions"),
+    listView: document.getElementById("wrong-book-list-view"),
+    reviewView: document.getElementById("wrong-book-review-view"),
+    dueCount: document.getElementById("wrong-book-due-count"),
+    totalCount: document.getElementById("wrong-book-total-count"),
+    startReview: document.getElementById("start-wrong-review"),
+    subject: document.getElementById("wrong-book-subject"),
+    status: document.getElementById("wrong-book-status"),
+    records: document.getElementById("wrong-book-records"),
+    importButton: document.getElementById("import-wrong-questions"),
+    exportButton: document.getElementById("export-wrong-questions"),
+    importInput: document.getElementById("wrong-question-import-input"),
+    reviewPosition: document.getElementById("wrong-review-position"),
+    reviewSubject: document.getElementById("wrong-review-subject"),
+    reviewProgress: document.getElementById("wrong-review-progress-bar"),
+    reviewContent: document.getElementById("wrong-review-content"),
+    reviewActions: document.querySelector(".wrong-review-actions")
+  };
+
+  if (!dom.book || !dom.open || !dom.records) return;
+
+  let databasePromise = null;
+  let taxonomy = { subjects: FALLBACK_SUBJECTS };
+  let records = [];
+  let scope = "due";
+  let reviewQueue = [];
+  let reviewIndex = 0;
+  let grading = false;
+
+  function refreshIcons() {
+    if (window.lucide) window.lucide.createIcons({ attrs: { "stroke-width": 2 } });
+  }
+
+  function createId(prefix = "wrong") {
+    return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  }
+
+  function stringValue(value, maxLength = 500) {
+    return typeof value === "string" ? value.trim().slice(0, maxLength) : "";
+  }
+
+  function localDate(value) {
+    return new Date(value).toLocaleDateString("zh-CN", { month: "numeric", day: "numeric" });
+  }
+
+  function startOfTomorrow() {
+    const date = new Date();
+    date.setHours(24, 0, 0, 0);
+    return date.getTime();
+  }
+
+  function setStatus(message = "", isError = false) {
+    dom.status.textContent = message;
+    dom.status.classList.toggle("error", isError);
+  }
+
+  function openDatabase() {
+    if (databasePromise) return databasePromise;
+    databasePromise = new Promise((resolve, reject) => {
+      if (!window.indexedDB) {
+        reject(new Error("当前浏览器不支持错题存储"));
+        return;
+      }
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+      request.onupgradeneeded = () => {
+        const database = request.result;
+        if (!database.objectStoreNames.contains(STORE_NAME)) {
+          const store = database.createObjectStore(STORE_NAME, { keyPath: "id" });
+          store.createIndex("createdAt", "createdAt");
+          store.createIndex("nextReviewAt", "review.nextReviewAt");
+          store.createIndex("subjectId", "subjectId");
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error || new Error("错题数据库打开失败"));
+    });
+    return databasePromise;
+  }
+
+  async function readAllRecords() {
+    const database = await openDatabase();
+    return new Promise((resolve, reject) => {
+      const request = database.transaction(STORE_NAME, "readonly").objectStore(STORE_NAME).getAll();
+      request.onsuccess = () => resolve(request.result || []);
+      request.onerror = () => reject(request.error || new Error("错题读取失败"));
+    });
+  }
+
+  async function writeRecord(record) {
+    const database = await openDatabase();
+    return new Promise((resolve, reject) => {
+      const request = database.transaction(STORE_NAME, "readwrite").objectStore(STORE_NAME).put(record);
+      request.onsuccess = () => resolve(record);
+      request.onerror = () => reject(request.error || new Error("错题保存失败"));
+    });
+  }
+
+  async function deleteRecordData(id) {
+    const database = await openDatabase();
+    return new Promise((resolve, reject) => {
+      const request = database.transaction(STORE_NAME, "readwrite").objectStore(STORE_NAME).delete(id);
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error || new Error("错题删除失败"));
+    });
+  }
+
+  function normalizeReview(value) {
+    return {
+      stage: Math.max(0, Number(value?.stage) || 0),
+      intervalDays: Math.max(0, Number(value?.intervalDays) || 0),
+      nextReviewAt: Number(value?.nextReviewAt) || Date.now(),
+      lastReviewedAt: Number(value?.lastReviewedAt) || 0,
+      history: Array.isArray(value?.history) ? value.history.slice(-100) : []
+    };
+  }
+
+  function normalizeKnowledge(value, index = 0) {
+    return {
+      id: stringValue(value?.id, 100) || `knowledge-${index}-${Math.random().toString(36).slice(2, 7)}`,
+      kind: stringValue(value?.kind, 30) || "knowledge",
+      title: stringValue(value?.title, 100) || "待复习知识",
+      summary: stringValue(value?.summary, 800),
+      details: Array.isArray(value?.details) ? value.details.map(item => stringValue(item, 300)).filter(Boolean).slice(0, 8) : []
+    };
+  }
+
+  function normalizeRecord(value) {
+    const now = Date.now();
+    return {
+      id: stringValue(value?.id, 120) || createId(),
+      version: 1,
+      title: stringValue(value?.title, 100) || "未命名错题",
+      subjectId: stringValue(value?.subjectId, 80),
+      subjectLabel: stringValue(value?.subjectLabel, 80) || "未分类",
+      typeId: stringValue(value?.typeId, 100),
+      typeLabel: stringValue(value?.typeLabel, 100) || "待分类",
+      correctAnswer: stringValue(value?.correctAnswer, 1000),
+      questionText: stringValue(value?.questionText, 12000),
+      images: Array.isArray(value?.images) ? value.images.map(image => ({
+        name: stringValue(image?.name, 200) || "题目图片",
+        type: stringValue(image?.type, 100),
+        dataUrl: typeof image?.dataUrl === "string" ? image.dataUrl : ""
+      })).filter(image => image.dataUrl.startsWith("data:image/")) : [],
+      answer: stringValue(value?.answer, 30000),
+      knowledge: Array.isArray(value?.knowledge) ? value.knowledge.map(normalizeKnowledge).slice(0, 16) : [],
+      recordFields: Array.isArray(value?.recordFields) ? value.recordFields.map(item => stringValue(item, 100)).filter(Boolean).slice(0, 16) : [],
+      source: {
+        sessionId: stringValue(value?.source?.sessionId, 120),
+        userMessageId: stringValue(value?.source?.userMessageId, 120),
+        assistantMessageId: stringValue(value?.source?.assistantMessageId, 120)
+      },
+      review: normalizeReview(value?.review),
+      createdAt: Number(value?.createdAt) || now,
+      updatedAt: Number(value?.updatedAt) || now
+    };
+  }
+
+  async function loadTaxonomy() {
+    try {
+      const response = await fetch(TAXONOMY_URL, { cache: "no-cache" });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const value = await response.json();
+      if (!Array.isArray(value?.subjects) || !value.subjects.length) throw new Error("分类数据无效");
+      taxonomy = value;
+    } catch {
+      taxonomy = { subjects: FALLBACK_SUBJECTS };
+    }
+    renderSubjectOptions();
+    return taxonomy;
+  }
+
+  function findSubject(subjectId, subjectLabel = "") {
+    return taxonomy.subjects.find(item => item.id === subjectId)
+      || taxonomy.subjects.find(item => item.label === subjectLabel)
+      || null;
+  }
+
+  function findType(subject, typeId, typeLabel = "") {
+    if (!subject) return null;
+    return (subject.types || []).find(item => item.id === typeId)
+      || (subject.types || []).find(item => item.label === typeLabel)
+      || null;
+  }
+
+  function compactTaxonomy() {
+    return taxonomy.subjects.map(subject => {
+      const types = (subject.types || []).map(type => `${type.id}=${type.label}`).join("；");
+      return `${subject.id}=${subject.label}${types ? `：[${types}]` : ""}`;
+    }).join("\n");
+  }
+
+  function renderSubjectOptions() {
+    const selected = dom.subject.value;
+    dom.subject.innerHTML = '<option value="">全部科目</option>';
+    taxonomy.subjects.forEach(subject => {
+      const option = document.createElement("option");
+      option.value = subject.id;
+      option.textContent = subject.label;
+      dom.subject.appendChild(option);
+    });
+    dom.subject.value = taxonomy.subjects.some(item => item.id === selected) ? selected : "";
+  }
+
+  function isDue(record) {
+    return Number(record.review?.nextReviewAt) <= Date.now();
+  }
+
+  function filteredRecords() {
+    const subject = dom.subject.value;
+    return records
+      .filter(record => scope === "all" || isDue(record))
+      .filter(record => !subject || record.subjectId === subject)
+      .sort((a, b) => {
+        if (scope === "due") return a.review.nextReviewAt - b.review.nextReviewAt || b.createdAt - a.createdAt;
+        return b.updatedAt - a.updatedAt;
+      });
+  }
+
+  function dueLabel(record) {
+    const next = Number(record.review.nextReviewAt) || Date.now();
+    if (next <= Date.now()) return "待复习";
+    if (next < startOfTomorrow()) return "今天";
+    return `${localDate(next)}复习`;
+  }
+
+  function createEmptyState() {
+    const empty = document.createElement("div");
+    empty.className = "wrong-book-empty";
+    empty.innerHTML = '<i data-lucide="book-open" aria-hidden="true"></i>';
+    const title = document.createElement("h2");
+    const copy = document.createElement("p");
+    if (!records.length) {
+      title.textContent = "还没有错题";
+      copy.textContent = "完成一道拍题搜题后，选择需要复习的知识并保存。";
+    } else if (scope === "due") {
+      title.textContent = "今天已经复习完了";
+      copy.textContent = "可以切换到“全部”查看已经收录的错题。";
+    } else {
+      title.textContent = "没有符合条件的错题";
+      copy.textContent = "更换科目筛选后再查看。";
+    }
+    empty.append(title, copy);
+    return empty;
+  }
+
+  function createRecordElement(record) {
+    const details = document.createElement("details");
+    details.className = "wrong-record";
+    details.dataset.recordId = record.id;
+    const summary = document.createElement("summary");
+    const main = document.createElement("div");
+    main.className = "wrong-record-main";
+    const meta = document.createElement("div");
+    meta.className = "wrong-record-meta";
+    [record.subjectLabel, record.typeLabel].filter(Boolean).forEach(value => {
+      const span = document.createElement("span");
+      span.textContent = value;
+      meta.appendChild(span);
+    });
+    const title = document.createElement("h2");
+    title.textContent = record.title;
+    const knowledge = document.createElement("p");
+    knowledge.className = "wrong-record-knowledge";
+    knowledge.textContent = record.knowledge.map(item => item.title).join("、") || "整题复习";
+    main.append(meta, title, knowledge);
+    const due = document.createElement("span");
+    due.className = `wrong-record-due${isDue(record) ? " today" : ""}`;
+    due.textContent = dueLabel(record);
+    summary.append(main, due);
+
+    const body = document.createElement("div");
+    body.className = "wrong-record-body";
+    if (record.questionText) {
+      const question = document.createElement("p");
+      question.className = "wrong-record-question";
+      question.textContent = record.questionText;
+      body.appendChild(question);
+    }
+    const items = document.createElement("div");
+    items.className = "wrong-record-items";
+    record.knowledge.forEach(item => {
+      const row = document.createElement("div");
+      row.className = "wrong-record-item";
+      const itemTitle = document.createElement("strong");
+      itemTitle.textContent = item.title;
+      const itemCopy = document.createElement("span");
+      itemCopy.textContent = [item.summary, ...item.details].filter(Boolean).join("；");
+      row.append(itemTitle);
+      if (itemCopy.textContent) row.appendChild(itemCopy);
+      items.appendChild(row);
+    });
+    body.appendChild(items);
+
+    const actions = document.createElement("div");
+    actions.className = "wrong-record-actions";
+    const review = document.createElement("button");
+    review.type = "button";
+    review.dataset.wrongReview = record.id;
+    review.title = "复习这道题";
+    review.setAttribute("aria-label", `复习${record.title}`);
+    review.innerHTML = '<i data-lucide="play" aria-hidden="true"></i>';
+    const remove = document.createElement("button");
+    remove.type = "button";
+    remove.dataset.wrongDelete = record.id;
+    remove.title = "删除错题";
+    remove.setAttribute("aria-label", `删除${record.title}`);
+    remove.innerHTML = '<i data-lucide="trash-2" aria-hidden="true"></i>';
+    actions.append(review, remove);
+    body.appendChild(actions);
+    details.append(summary, body);
+    return details;
+  }
+
+  function updateCounts() {
+    const due = records.filter(isDue).length;
+    dom.dueCount.textContent = String(due);
+    dom.totalCount.textContent = String(records.length);
+    dom.badge.textContent = due > 99 ? "99+" : String(due);
+    dom.badge.hidden = due === 0;
+    dom.badge.setAttribute("aria-label", `${due}道待复习`);
+    const queue = filteredRecords();
+    dom.startReview.disabled = queue.length === 0;
+  }
+
+  function renderList() {
+    updateCounts();
+    dom.records.innerHTML = "";
+    const filtered = filteredRecords();
+    if (!filtered.length) dom.records.appendChild(createEmptyState());
+    else filtered.forEach(record => dom.records.appendChild(createRecordElement(record)));
+    refreshIcons();
+  }
+
+  async function refreshRecords() {
+    try {
+      records = (await readAllRecords()).map(normalizeRecord);
+      setStatus("");
+    } catch (error) {
+      records = [];
+      setStatus(error.message || "错题读取失败", true);
+    }
+    renderList();
+    return records;
+  }
+
+  function setListMode() {
+    dom.listView.hidden = false;
+    dom.reviewView.hidden = true;
+    dom.kicker.textContent = "REVIEW";
+    dom.title.textContent = "错题本";
+    dom.transferActions.hidden = false;
+    refreshIcons();
+  }
+
+  async function openBook(recordId = "") {
+    dom.book.hidden = false;
+    setListMode();
+    if (recordId) {
+      scope = "all";
+      document.querySelectorAll("[data-wrong-scope]").forEach(button => {
+        const active = button.dataset.wrongScope === "all";
+        button.classList.toggle("active", active);
+        button.setAttribute("aria-selected", String(active));
+      });
+    }
+    await refreshRecords();
+    if (recordId) {
+      requestAnimationFrame(() => {
+        const row = Array.from(dom.records.querySelectorAll("[data-record-id]")).find(item => item.dataset.recordId === recordId);
+        if (!row) return;
+        row.open = true;
+        row.scrollIntoView({ behavior: "smooth", block: "start" });
+      });
+    }
+  }
+
+  function closeBook() {
+    if (!dom.reviewView.hidden) {
+      setListMode();
+      renderList();
+      return;
+    }
+    dom.book.hidden = true;
+  }
+
+  function renderSafeMarkdown(element, source) {
+    const text = String(source || "");
+    if (!window.marked?.parse || !window.DOMPurify?.sanitize) {
+      element.textContent = text;
+      return;
+    }
+    element.innerHTML = window.DOMPurify.sanitize(window.marked.parse(text, { gfm: true, breaks: true }), {
+      USE_PROFILES: { html: true },
+      FORBID_TAGS: ["style"],
+      FORBID_ATTR: ["style"]
+    });
+    element.querySelectorAll("a[href]").forEach(link => {
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+    });
+  }
+
+  function renderReview() {
+    dom.reviewActions.querySelectorAll("button").forEach(button => {
+      button.disabled = false;
+    });
+    const record = reviewQueue[reviewIndex];
+    if (!record) {
+      setListMode();
+      setStatus("本轮复习完成。");
+      refreshRecords();
+      return;
+    }
+    dom.listView.hidden = true;
+    dom.reviewView.hidden = false;
+    dom.kicker.textContent = "REVIEWING";
+    dom.title.textContent = "复习错题";
+    dom.transferActions.hidden = true;
+    dom.reviewPosition.textContent = `${reviewIndex + 1} / ${reviewQueue.length}`;
+    dom.reviewSubject.textContent = `${record.subjectLabel} · ${record.typeLabel}`;
+    dom.reviewProgress.style.width = `${((reviewIndex + 1) / reviewQueue.length) * 100}%`;
+    dom.reviewContent.innerHTML = "";
+
+    if (record.images.length) {
+      const images = document.createElement("div");
+      images.className = "wrong-review-source-images";
+      record.images.forEach(image => {
+        const preview = document.createElement("img");
+        preview.src = image.dataUrl;
+        preview.alt = image.name;
+        images.appendChild(preview);
+      });
+      dom.reviewContent.appendChild(images);
+    }
+    const question = document.createElement("p");
+    question.className = "wrong-review-question";
+    question.textContent = record.questionText || "请回忆原题的判断方法和关键知识。";
+    dom.reviewContent.appendChild(question);
+
+    const heading = document.createElement("h2");
+    heading.className = "wrong-review-heading";
+    heading.textContent = "本题需要掌握";
+    dom.reviewContent.appendChild(heading);
+    const knowledge = document.createElement("div");
+    knowledge.className = "wrong-review-knowledge";
+    record.knowledge.forEach(item => {
+      const row = document.createElement("section");
+      row.className = "wrong-review-knowledge-item";
+      const title = document.createElement("strong");
+      title.textContent = item.title;
+      const copy = document.createElement("p");
+      copy.textContent = [item.summary, ...item.details].filter(Boolean).join("；");
+      row.append(title);
+      if (copy.textContent) row.appendChild(copy);
+      knowledge.appendChild(row);
+    });
+    dom.reviewContent.appendChild(knowledge);
+
+    if (record.answer) {
+      const answer = document.createElement("details");
+      answer.className = "wrong-review-answer";
+      answer.innerHTML = '<summary><i data-lucide="message-square-text" aria-hidden="true"></i><span>查看原解析</span></summary>';
+      const copy = document.createElement("div");
+      copy.className = "wrong-review-answer-copy solver-markdown";
+      renderSafeMarkdown(copy, record.answer);
+      answer.appendChild(copy);
+      dom.reviewContent.appendChild(answer);
+    }
+    dom.reviewView.scrollTo({ top: 0, behavior: "auto" });
+    refreshIcons();
+  }
+
+  function startReview(recordId = "") {
+    if (recordId) reviewQueue = records.filter(record => record.id === recordId);
+    else reviewQueue = filteredRecords();
+    if (!reviewQueue.length) return;
+    reviewIndex = 0;
+    renderReview();
+  }
+
+  function reviewSchedule(record, grade) {
+    const previousStage = Math.max(0, Number(record.review.stage) || 0);
+    let stage;
+    let intervalDays;
+    if (grade === "forgot") {
+      stage = 0;
+      intervalDays = 1;
+    } else if (grade === "fuzzy") {
+      const intervals = [1, 2, 4, 7, 14, 30, 60];
+      stage = Math.max(1, previousStage + 1);
+      intervalDays = intervals[Math.min(stage - 1, intervals.length - 1)];
+    } else {
+      const intervals = [3, 7, 14, 30, 60, 120, 240];
+      stage = previousStage + 1;
+      intervalDays = intervals[Math.min(previousStage, intervals.length - 1)];
+    }
+    const reviewedAt = Date.now();
+    record.review = {
+      stage,
+      intervalDays,
+      lastReviewedAt: reviewedAt,
+      nextReviewAt: reviewedAt + intervalDays * DAY,
+      history: [...(record.review.history || []), { reviewedAt, grade, intervalDays }].slice(-100)
+    };
+    record.updatedAt = reviewedAt;
+  }
+
+  async function gradeReview(grade) {
+    const record = reviewQueue[reviewIndex];
+    if (grading || !record || !["forgot", "fuzzy", "mastered"].includes(grade)) return;
+    grading = true;
+    dom.reviewActions.querySelectorAll("button").forEach(button => {
+      button.disabled = true;
+    });
+    try {
+      reviewSchedule(record, grade);
+      await writeRecord(record);
+      const index = records.findIndex(item => item.id === record.id);
+      if (index >= 0) records[index] = record;
+      reviewIndex += 1;
+      renderReview();
+      updateCounts();
+    } finally {
+      grading = false;
+      if (!dom.reviewView.hidden) {
+        dom.reviewActions.querySelectorAll("button").forEach(button => {
+          button.disabled = false;
+        });
+      }
+    }
+  }
+
+  function jsonContent(value) {
+    if (typeof value === "string") return value;
+    if (!Array.isArray(value)) return "";
+    return value.map(part => typeof part === "string" ? part : (part?.text || part?.content || "")).join("");
+  }
+
+  function parseJsonContent(value) {
+    const text = jsonContent(value).trim().replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/i, "");
+    try {
+      return JSON.parse(text);
+    } catch {
+      const start = text.indexOf("{");
+      const end = text.lastIndexOf("}");
+      if (start >= 0 && end > start) return JSON.parse(text.slice(start, end + 1));
+      throw new Error("模型没有返回可识别的错题分类");
+    }
+  }
+
+  function analysisSchema() {
+    return {
+      type: "object",
+      properties: {
+        subjectId: { type: "string", description: "必须使用给定分类中的科目ID" },
+        subjectLabel: { type: "string" },
+        typeId: { type: "string", description: "必须使用该科目下的题型ID" },
+        typeLabel: { type: "string" },
+        confidence: { type: "number", minimum: 0, maximum: 1 },
+        title: { type: "string", description: "不超过30字的错题标题" },
+        correctAnswer: { type: "string" },
+        candidates: {
+          type: "array",
+          minItems: 1,
+          maxItems: 10,
+          items: {
+            type: "object",
+            properties: {
+              kind: { type: "string", enum: ["term", "rule", "formula", "method", "mistake", "material_point", "argument", "fact", "other"] },
+              title: { type: "string" },
+              summary: { type: "string" },
+              details: { type: "array", items: { type: "string" }, maxItems: 8 }
+            },
+            required: ["kind", "title", "summary", "details"],
+            additionalProperties: false
+          }
+        }
+      },
+      required: ["subjectId", "subjectLabel", "typeId", "typeLabel", "confidence", "title", "correctAnswer", "candidates"],
+      additionalProperties: false
+    };
+  }
+
+  function analysisMessages(userMessage, assistantText) {
+    const instructions = [
+      "你是公务员考试错题整理器。请识别题目所属科目和具体题型，并提取值得以后单独复习的最小知识单元。",
+      "只能从下面给定的科目ID和题型ID中选择。不要创造新的ID。",
+      compactTaxonomy(),
+      "提取规则：",
+      "1. 选词填空必须把每个有辨析价值的候选词或成语分别作为候选项，并解释词义、侧重点、搭配和易混点。",
+      "2. 政治、常识、法律题按可独立记忆的事实、政策、概念或法条拆分。",
+      "3. 数量、资料、图形、逻辑和科学题提取可复用的公式、模型、规律、论证方法或实验原则，不要只复述答案。",
+      "4. 申论提取遗漏要点、规范表达、分类方式、文种规则、论点或论据。",
+      "5. 候选项应有2到8个；每项标题简短，summary可脱离原题独立复习。不要输出整题候选项，页面会另行提供。",
+      "6. 如果图片信息不完整，仍需根据可见题干和解析做最稳妥分类，不要编造原题事实。"
+    ].join("\n");
+    const content = [{
+      type: "text",
+      text: `题目文字：\n${userMessage.text || "（题目主要在图片中）"}\n\n已有解析：\n${assistantText}`
+    }];
+    (userMessage.images || []).forEach(image => {
+      if (image.dataUrl) content.push({ type: "image_url", image_url: { url: image.dataUrl } });
+    });
+    return [{ role: "system", content: instructions }, { role: "user", content }];
+  }
+
+  async function requestAnalysis(body, apiKey, headers, signal) {
+    const response = await fetch(CHAT_ENDPOINT, {
+      method: "POST",
+      signal,
+      headers: typeof headers === "function" ? headers(apiKey) : {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(body)
+    });
+    if (!response.ok) {
+      const payload = await response.json().catch(() => null);
+      const error = new Error(payload?.error?.message || `错题识别请求失败（${response.status}）`);
+      error.status = response.status;
+      throw error;
+    }
+    const payload = await response.json();
+    const message = payload?.choices?.[0]?.message;
+    if (!message) throw new Error("模型没有返回错题分类");
+    return parseJsonContent(message.content);
+  }
+
+  function normalizeAnalysis(value) {
+    const subject = findSubject(value?.subjectId, value?.subjectLabel);
+    const type = findType(subject, value?.typeId, value?.typeLabel);
+    const candidates = Array.isArray(value?.candidates) ? value.candidates.map((item, index) => ({
+      id: `candidate-${index}-${Math.random().toString(36).slice(2, 7)}`,
+      kind: stringValue(item?.kind, 30) || "knowledge",
+      title: stringValue(item?.title, 100) || `知识点${index + 1}`,
+      summary: stringValue(item?.summary, 800),
+      details: Array.isArray(item?.details) ? item.details.map(detail => stringValue(detail, 300)).filter(Boolean).slice(0, 8) : []
+    })).filter(item => item.title).slice(0, 10) : [];
+    if (!candidates.length) throw new Error("没有识别到可记录的知识点");
+    return {
+      subjectId: subject?.id || stringValue(value?.subjectId, 80),
+      subjectLabel: subject?.label || stringValue(value?.subjectLabel, 80) || "未分类",
+      typeId: type?.id || stringValue(value?.typeId, 100),
+      typeLabel: type?.label || stringValue(value?.typeLabel, 100) || "待分类",
+      confidence: Math.max(0, Math.min(1, Number(value?.confidence) || 0)),
+      title: stringValue(value?.title, 100) || "拍题错题",
+      correctAnswer: stringValue(value?.correctAnswer, 1000),
+      candidates,
+      recordFields: Array.isArray(type?.recordFields) ? type.recordFields.slice() : []
+    };
+  }
+
+  async function analyzeQuestion({ apiKey, model, headers, userMessage, assistantText, signal }) {
+    await taxonomyReady;
+    const messages = analysisMessages(userMessage, assistantText);
+    const base = { model, messages, stream: false };
+    let value;
+    try {
+      value = await requestAnalysis({
+        ...base,
+        response_format: {
+          type: "json_schema",
+          json_schema: { name: "wrong_question_analysis", strict: true, schema: analysisSchema() }
+        },
+        plugins: [{ id: "response-healing" }],
+        provider: { require_parameters: true }
+      }, apiKey, headers, signal);
+    } catch (error) {
+      if (error?.name === "AbortError") throw error;
+      value = await requestAnalysis({
+        ...base,
+        messages: [
+          ...messages,
+          { role: "system", content: "仅输出一个合法JSON对象，不要使用Markdown代码块。字段必须为subjectId、subjectLabel、typeId、typeLabel、confidence、title、correctAnswer、candidates；candidates每项包含kind、title、summary、details。" }
+        ],
+        response_format: { type: "json_object" },
+        plugins: [{ id: "response-healing" }]
+      }, apiKey, headers, signal).catch(async fallbackError => {
+        if (fallbackError?.name === "AbortError") throw fallbackError;
+        return requestAnalysis({
+          ...base,
+          messages: [
+            ...messages,
+            { role: "system", content: "仅输出一个合法JSON对象，不要使用Markdown代码块。" }
+          ]
+        }, apiKey, headers, signal);
+      });
+    }
+    return normalizeAnalysis(value);
+  }
+
+  async function saveFromConversation({ sessionId, userMessage, assistantMessage, selectedIds, customText }) {
+    const analysis = assistantMessage.wrongQuestionAnalysis;
+    if (!analysis) throw new Error("请先完成错题识别");
+    const selected = new Set(selectedIds || []);
+    const knowledge = [];
+    if (selected.has("__whole__")) {
+      knowledge.push({
+        id: "whole-question",
+        kind: "whole",
+        title: "整道题与解题方法",
+        summary: "复习原题条件、正确答案和完整解析。",
+        details: []
+      });
+    }
+    analysis.candidates.filter(item => selected.has(item.id)).forEach(item => knowledge.push(normalizeKnowledge(item, knowledge.length)));
+    const custom = stringValue(customText, 300);
+    if (custom) {
+      knowledge.push({ id: createId("custom"), kind: "custom", title: custom, summary: "用户补充的复习内容", details: [] });
+    }
+    if (!knowledge.length) throw new Error("请至少选择或填写一项需要复习的内容");
+
+    const existing = assistantMessage.wrongQuestionId
+      ? records.find(item => item.id === assistantMessage.wrongQuestionId)
+      : records.find(item => item.source.assistantMessageId === assistantMessage.id && item.source.sessionId === sessionId);
+    const now = Date.now();
+    const record = normalizeRecord({
+      id: existing?.id || createId(),
+      title: analysis.title,
+      subjectId: analysis.subjectId,
+      subjectLabel: analysis.subjectLabel,
+      typeId: analysis.typeId,
+      typeLabel: analysis.typeLabel,
+      correctAnswer: analysis.correctAnswer,
+      questionText: userMessage.text || "请根据原题图片复习。",
+      images: userMessage.images || [],
+      answer: assistantMessage.text,
+      knowledge,
+      recordFields: analysis.recordFields || [],
+      source: { sessionId, userMessageId: userMessage.id, assistantMessageId: assistantMessage.id },
+      review: existing?.review || normalizeReview(),
+      createdAt: existing?.createdAt || now,
+      updatedAt: now
+    });
+    await writeRecord(record);
+    const index = records.findIndex(item => item.id === record.id);
+    if (index >= 0) records[index] = record;
+    else records.unshift(record);
+    renderList();
+    window.dispatchEvent(new CustomEvent("wrong-question:saved", { detail: { record } }));
+    return record;
+  }
+
+  async function removeRecord(record) {
+    if (!record || !window.confirm(`确定删除“${record.title}”吗？此操作无法撤销。`)) return;
+    await deleteRecordData(record.id);
+    records = records.filter(item => item.id !== record.id);
+    renderList();
+    window.dispatchEvent(new CustomEvent("wrong-question:deleted", { detail: { record } }));
+  }
+
+  function exportRecords() {
+    const payload = {
+      kind: "summer-politics-wrong-questions",
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      records
+    };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `错题本-${new Date().toISOString().slice(0, 10)}.json`;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+    setStatus(`已导出${records.length}道错题。`);
+  }
+
+  async function importRecords(file) {
+    if (!file) return;
+    if (file.size > MAX_IMPORT_BYTES) throw new Error("导入文件不能超过30MB");
+    const payload = JSON.parse(await file.text());
+    if (payload?.kind !== "summer-politics-wrong-questions" || !Array.isArray(payload.records)) {
+      throw new Error("这不是有效的错题本备份文件");
+    }
+    const incoming = payload.records.map(normalizeRecord);
+    const existing = new Map(records.map(record => [record.id, record]));
+    let changed = 0;
+    for (const record of incoming) {
+      const current = existing.get(record.id);
+      if (!current || record.updatedAt >= current.updatedAt) {
+        await writeRecord(record);
+        existing.set(record.id, record);
+        changed += 1;
+      }
+    }
+    records = [...existing.values()];
+    renderList();
+    setStatus(`导入完成，更新${changed}道错题。`);
+  }
+
+  dom.open.addEventListener("click", () => openBook());
+  dom.close.addEventListener("click", closeBook);
+  document.querySelectorAll("[data-wrong-scope]").forEach(button => {
+    button.addEventListener("click", () => {
+      scope = button.dataset.wrongScope;
+      document.querySelectorAll("[data-wrong-scope]").forEach(item => {
+        const active = item === button;
+        item.classList.toggle("active", active);
+        item.setAttribute("aria-selected", String(active));
+      });
+      renderList();
+    });
+  });
+  dom.subject.addEventListener("change", renderList);
+  dom.startReview.addEventListener("click", () => startReview());
+  dom.records.addEventListener("click", event => {
+    const reviewButton = event.target.closest("button[data-wrong-review]");
+    const deleteButton = event.target.closest("button[data-wrong-delete]");
+    if (reviewButton) {
+      event.preventDefault();
+      startReview(reviewButton.dataset.wrongReview);
+    }
+    if (deleteButton) {
+      event.preventDefault();
+      removeRecord(records.find(item => item.id === deleteButton.dataset.wrongDelete)).catch(error => setStatus(error.message, true));
+    }
+  });
+  dom.reviewActions.addEventListener("click", event => {
+    const button = event.target.closest("button[data-review-grade]");
+    if (button) gradeReview(button.dataset.reviewGrade).catch(error => setStatus(error.message, true));
+  });
+  dom.exportButton.addEventListener("click", exportRecords);
+  dom.importButton.addEventListener("click", () => dom.importInput.click());
+  dom.importInput.addEventListener("change", async () => {
+    try {
+      await importRecords(dom.importInput.files?.[0]);
+    } catch (error) {
+      setStatus(error.message || "错题导入失败", true);
+    } finally {
+      dom.importInput.value = "";
+    }
+  });
+  window.addEventListener("summer-politics:tabchange", () => {
+    if (!dom.book.hidden) dom.book.hidden = true;
+  });
+
+  const taxonomyReady = loadTaxonomy();
+  const ready = Promise.all([taxonomyReady, refreshRecords()]).then(() => true);
+
+  window.wrongQuestionBook = {
+    ready,
+    analyzeQuestion,
+    saveFromConversation,
+    open: openBook,
+    refresh: refreshRecords,
+    getTypeDefinition(subjectId, typeId) {
+      const subject = findSubject(subjectId);
+      return findType(subject, typeId);
+    }
+  };
+
+  refreshIcons();
+})();


### PR DESCRIPTION
## Summary
- classify solved civil-service exam questions into the researched 9-subject, 75-type taxonomy
- let users select reusable knowledge points and save them from each AI answer
- add a persistent wrong-question book with subject filters, due counts, spaced review, and JSON import/export
- include the new assets in GitHub Pages and Cloudflare build output

## Verification
- node --check search.js
- node --check wrong-questions.js
- python -m py_compile build_public_site.py
- mocked OpenRouter browser flow at 390x844 and 820x1180
- no horizontal overflow; save/list/review scheduling passed